### PR TITLE
Feat(framelib): tighten v2 package generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,14 @@ cython_debug/
 
 .vscode
 debug
+
+# Local task/session notes
+tasks/
+
+# Local agent/tooling files
+.agents/
+.claude/
+.qwen/
+.codex
+AGENTS.md
+CLAUDE.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,23 +7,16 @@ ci:
   autoupdate_commit_msg: ":arrow_up: auto update by pre-commit hooks"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.9
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.1.0
+    rev: 26.3.1
     hooks:
       - id: black
-        stages: [pre-commit]
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types_or: [markdown, yaml, json]
         stages: [pre-commit]
 
   - repo: https://github.com/dannysepler/rm_unneeded_f_str
@@ -55,6 +48,6 @@ repos:
       - id: poetry-install
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.0
+    rev: 0.11.6
     hooks:
       - id: uv-lock

--- a/paicorelib/core_defs_v2.py
+++ b/paicorelib/core_defs_v2.py
@@ -90,6 +90,7 @@ class DataWidth(IntEnum):
     WIDTH_16BIT = 4
     WIDTH_32BIT = 5
 
+
 @unique
 class DataSign(IntEnum):
     """Input/output/weight data sign."""

--- a/paicorelib/framelib/base.py
+++ b/paicorelib/framelib/base.py
@@ -11,7 +11,7 @@ from .frame_defs import FF, FFV2, FT, FramePackageType, Online_WF1F_SubType
 from .frame_defs import FrameHeader as FH
 from .frame_defs import OfflineNeuRAMFormat as Off_NRAMF
 from .types import FRAME_DTYPE, FrameArrayType
-from .utils import header2type
+from .utils import header2type, pack_field
 
 __all__ = [
     "Frame",
@@ -21,8 +21,10 @@ __all__ = [
     "FrameV2",
     "FramePackageHeaderV2",
     "get_frame_dest",
-    "get_frame_destV2",
+    "get_frame_dest_v2",
 ]
+
+_p = pack_field
 
 
 @dataclass
@@ -247,24 +249,23 @@ class FramePackage(_FrameBase):
         return type(self)(self.chip_coord, self.core_coord, self.rid, payload, packages)
 
 
-def get_frame_destV2(
+def get_frame_dest_v2(
     header: FH, pkt_offset: CoordZXYOffset, pkt_ncopy: AERPacketZXYCopy
 ) -> int:
     oz, ox, oy = pkt_offset.to_sign_magnitude()
     nz, nx, ny = pkt_ncopy.to_sign_magnitude()
     pkt_addr = (
-        (
-            ((oz & FFV2.GENERAL_CORE_XY_ADDR_MASK) << FFV2.GENERAL_CORE_XY_ADDR_OFFSET)
-            | ((ox & FFV2.GENERAL_CORE_X_ADDR_MASK) << FFV2.GENERAL_CORE_X_ADDR_OFFSET)
-            | ((oy & FFV2.GENERAL_CORE_Y_ADDR_MASK) << FFV2.GENERAL_CORE_Y_ADDR_OFFSET)
-        )
-        | ((nz & FFV2.GENERAL_COPY_XY_ADDR_MASK) << FFV2.GENERAL_COPY_XY_ADDR_OFFSET)
-        | ((nx & FFV2.GENERAL_COPY_X_ADDR_MASK) << FFV2.GENERAL_COPY_X_ADDR_OFFSET)
-        | ((ny & FFV2.GENERAL_COPY_Y_ADDR_MASK) << FFV2.GENERAL_COPY_Y_ADDR_OFFSET)
+        _p(oz, FFV2.GENERAL_CORE_XY_ADDR_OFFSET, FFV2.GENERAL_CORE_XY_ADDR_MASK)
+        | _p(ox, FFV2.GENERAL_CORE_X_ADDR_OFFSET, FFV2.GENERAL_CORE_X_ADDR_MASK)
+        | _p(oy, FFV2.GENERAL_CORE_Y_ADDR_OFFSET, FFV2.GENERAL_CORE_Y_ADDR_MASK)
+        | _p(nz, FFV2.GENERAL_COPY_XY_ADDR_OFFSET, FFV2.GENERAL_COPY_XY_ADDR_MASK)
+        | _p(nx, FFV2.GENERAL_COPY_X_ADDR_OFFSET, FFV2.GENERAL_COPY_X_ADDR_MASK)
+        | _p(ny, FFV2.GENERAL_COPY_Y_ADDR_OFFSET, FFV2.GENERAL_COPY_Y_ADDR_MASK)
     )
     return (
-        (header.value & FFV2.GENERAL_HEADER_MASK) << FFV2.GENERAL_HEADER_OFFSET
-    ) | pkt_addr
+        _p(header.value, FFV2.GENERAL_HEADER_OFFSET, FFV2.GENERAL_HEADER_MASK)
+        | pkt_addr
+    )
 
 
 @dataclass
@@ -277,31 +278,17 @@ class _FrameBaseV2:
         oz, ox, oy = self.pkt_offset.to_sign_magnitude()
         nz, nx, ny = self.pkt_ncopy.to_sign_magnitude()
         return (
-            (
-                (
-                    (oz & FFV2.GENERAL_CORE_XY_ADDR_MASK)
-                    << FFV2.GENERAL_CORE_XY_ADDR_OFFSET
-                )
-                | (
-                    (ox & FFV2.GENERAL_CORE_X_ADDR_MASK)
-                    << FFV2.GENERAL_CORE_X_ADDR_OFFSET
-                )
-                | (
-                    (oy & FFV2.GENERAL_CORE_Y_ADDR_MASK)
-                    << FFV2.GENERAL_CORE_Y_ADDR_OFFSET
-                )
-            )
-            | (
-                (nz & FFV2.GENERAL_COPY_XY_ADDR_MASK)
-                << FFV2.GENERAL_COPY_XY_ADDR_OFFSET
-            )
-            | ((nx & FFV2.GENERAL_COPY_X_ADDR_MASK) << FFV2.GENERAL_COPY_X_ADDR_OFFSET)
-            | ((ny & FFV2.GENERAL_COPY_Y_ADDR_MASK) << FFV2.GENERAL_COPY_Y_ADDR_OFFSET)
+            _p(oz, FFV2.GENERAL_CORE_XY_ADDR_OFFSET, FFV2.GENERAL_CORE_XY_ADDR_MASK)
+            | _p(ox, FFV2.GENERAL_CORE_X_ADDR_OFFSET, FFV2.GENERAL_CORE_X_ADDR_MASK)
+            | _p(oy, FFV2.GENERAL_CORE_Y_ADDR_OFFSET, FFV2.GENERAL_CORE_Y_ADDR_MASK)
+            | _p(nz, FFV2.GENERAL_COPY_XY_ADDR_OFFSET, FFV2.GENERAL_COPY_XY_ADDR_MASK)
+            | _p(nx, FFV2.GENERAL_COPY_X_ADDR_OFFSET, FFV2.GENERAL_COPY_X_ADDR_MASK)
+            | _p(ny, FFV2.GENERAL_COPY_Y_ADDR_OFFSET, FFV2.GENERAL_COPY_Y_ADDR_MASK)
         )
 
     @property
     def frame_dest(self) -> int:
-        return get_frame_destV2(self.header, self.pkt_offset, self.pkt_ncopy)
+        return get_frame_dest_v2(self.header, self.pkt_offset, self.pkt_ncopy)
 
     def __str__(self) -> str:
         text = "Frame info:"
@@ -354,8 +341,7 @@ class FrameV2(_FrameBaseV2):
     def value(self) -> FrameArrayType:
         """Get the full frames of the frame."""
         frame = self.frame_dest | (
-            (int(self.payload) & FFV2.GENERAL_PAYLOAD_MASK)
-            << FFV2.GENERAL_PAYLOAD_OFFSET
+            _p(self.payload, FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK)
         )
         return np.array([frame], dtype=FRAME_DTYPE)
 
@@ -385,8 +371,11 @@ class FramePackageHeaderV2(_FrameBaseV2):
     def value(self) -> FrameArrayType:
         """Get the full frames of the frame package header."""
         frame = self.frame_dest | (
-            (int(self.payload.value) & FFV2.GENERAL_PAYLOAD_MASK)
-            << FFV2.GENERAL_PAYLOAD_OFFSET
+            _p(
+                self.payload.value,
+                FFV2.GENERAL_PAYLOAD_OFFSET,
+                FFV2.GENERAL_PAYLOAD_MASK,
+            )
         )
         return np.array([frame], dtype=FRAME_DTYPE)
 

--- a/paicorelib/framelib/frame_gen_v2.py
+++ b/paicorelib/framelib/frame_gen_v2.py
@@ -1,5 +1,6 @@
 import math
-from typing import Any, Literal
+from collections.abc import Sequence
+from typing import Any, Literal, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -16,9 +17,10 @@ from ..neuron_model_v2 import (
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
+    OfflineNeuHalfAttrsV2,
 )
 from ..routing_hexa import AERPacketZXYCopy
-from .base import FramePackageHeaderV2, FrameV2, get_frame_destV2
+from .base import FramePackageHeaderV2, FrameV2, get_frame_dest_v2
 from .frame_defs import FrameHeader as FH
 from .frame_defs import FramePackageType
 from .frame_defs import OfflineConfigFrame1FormatV2 as Off_Cfg1_V2
@@ -34,9 +36,25 @@ from .types import (
     LUTActivationType,
     LUTPotentialType,
 )
-from .utils import _mask, bin_split
+from .utils import _mask, bin_split, pack_field
 
 __all__ = ["FrameGenV2", "OfflineFrameGenV2"]
+
+DataWidthLE8 = Literal[1, 2, 4, 8]
+DataWidthLE8Like = DataWidth | DataWidthLE8
+
+_p = pack_field
+
+
+def _normalize_width_le8(
+    width: DataWidthLE8Like, *, name: str = "width"
+) -> DataWidthLE8:
+    width_bits = (1 << width.value) if isinstance(width, DataWidth) else int(width)
+
+    if width_bits not in (1, 2, 4, 8):
+        raise ValueError(f"'{name}' only supports 1/2/4/8-bit widths, got {width}.")
+
+    return cast(DataWidthLE8, width_bits)
 
 
 class FrameGenV2:
@@ -88,109 +106,131 @@ class OfflineFrameGenV2(FrameGenV2):
         )
         test_core_y_h2, test_core_y_l4 = bin_split(y, 4, 2)
         w1 = (
-            ((core_reg["snn_ann"] & F.Word1.SNN_ANN_MASK) << F.Word1.SNN_ANN_OFFSET)
-            | (
-                (core_reg["max_pooling"] & F.Word1.MAX_POOLING_MASK)
-                << F.Word1.MAX_POOLING_OFFSET
+            _p(core_reg["snn_ann"], F.Word1.SNN_ANN_OFFSET, F.Word1.SNN_ANN_MASK)
+            | _p(
+                core_reg["max_pooling"],
+                F.Word1.MAX_POOLING_OFFSET,
+                F.Word1.MAX_POOLING_MASK,
             )
-            | (
-                (core_reg["add_potential"] & F.Word1.ADD_POTENTIAL_MASK)
-                << F.Word1.ADD_POTENTIAL_OFFSET
+            | _p(
+                core_reg["add_potential"],
+                F.Word1.ADD_POTENTIAL_OFFSET,
+                F.Word1.ADD_POTENTIAL_MASK,
             )
-            | (
-                (core_reg["zero_output"] & F.Word1.ZERO_OUTPUT_MASK)
-                << F.Word1.ZERO_OUTPUT_OFFSET
+            | _p(
+                core_reg["zero_output"],
+                F.Word1.ZERO_OUTPUT_OFFSET,
+                F.Word1.ZERO_OUTPUT_MASK,
             )
-            | (
-                (core_reg["input_sign"] & F.Word1.INPUT_SIGN_MASK)
-                << F.Word1.INPUT_SIGN_OFFSET
+            | _p(
+                core_reg["input_sign"],
+                F.Word1.INPUT_SIGN_OFFSET,
+                F.Word1.INPUT_SIGN_MASK,
             )
-            | (
-                (core_reg["input_width"] & F.Word1.INPUT_WIDTH_MASK)
-                << F.Word1.INPUT_WIDTH_OFFSET
+            | _p(
+                core_reg["input_width"],
+                F.Word1.INPUT_WIDTH_OFFSET,
+                F.Word1.INPUT_WIDTH_MASK,
             )
-            | (
-                (core_reg["output_sign"] & F.Word1.OUTPUT_SIGN_MASK)
-                << F.Word1.OUTPUT_SIGN_OFFSET
+            | _p(
+                core_reg["output_sign"],
+                F.Word1.OUTPUT_SIGN_OFFSET,
+                F.Word1.OUTPUT_SIGN_MASK,
             )
-            | (
-                (core_reg["output_width"] & F.Word1.OUTPUT_WIDTH_MASK)
-                << F.Word1.OUTPUT_WIDTH_OFFSET
+            | _p(
+                core_reg["output_width"],
+                F.Word1.OUTPUT_WIDTH_OFFSET,
+                F.Word1.OUTPUT_WIDTH_MASK,
             )
-            | (
-                (core_reg["weight_sign"] & F.Word1.WEIGHT_SIGN_MASK)
-                << F.Word1.WEIGHT_SIGN_OFFSET
+            | _p(
+                core_reg["weight_sign"],
+                F.Word1.WEIGHT_SIGN_OFFSET,
+                F.Word1.WEIGHT_SIGN_MASK,
             )
-            | (
-                (core_reg["weight_width"] & F.Word1.WEIGHT_WIDTH_MASK)
-                << F.Word1.WEIGHT_WIDTH_OFFSET
+            | _p(
+                core_reg["weight_width"],
+                F.Word1.WEIGHT_WIDTH_OFFSET,
+                F.Word1.WEIGHT_WIDTH_MASK,
             )
-            | ((core_reg["lcn"] & F.Word1.LCN_MASK) << F.Word1.LCN_OFFSET)
-            | (
-                (core_reg["target_lcn"] & F.Word1.TARGET_LCN_MASK)
-                << F.Word1.TARGET_LCN_OFFSET
+            | _p(core_reg["lcn"], F.Word1.LCN_OFFSET, F.Word1.LCN_MASK)
+            | _p(
+                core_reg["target_lcn"],
+                F.Word1.TARGET_LCN_OFFSET,
+                F.Word1.TARGET_LCN_MASK,
             )
-            | (
-                (core_reg["axon_skew"] & F.Word1.AXON_SKEW_MASK)
-                << F.Word1.AXON_SKEW_OFFSET
+            | _p(
+                core_reg["axon_skew"], F.Word1.AXON_SKEW_OFFSET, F.Word1.AXON_SKEW_MASK
             )
-            | (
-                (core_reg["neuron_number"] & F.Word1.NEURON_NUMBER_MASK)
-                << F.Word1.NEURON_NUMBER_OFFSET
+            | _p(
+                core_reg["neuron_number"],
+                F.Word1.NEURON_NUMBER_OFFSET,
+                F.Word1.NEURON_NUMBER_MASK,
             )
-            | ((z & F.Word1.TEST_CORE_XY_MASK) << F.Word1.TEST_CORE_XY_OFFSET)
-            | ((x & F.Word1.TEST_CORE_X_MASK) << F.Word1.TEST_CORE_X_OFFSET)
-            | (
-                (test_core_y_h2 & F.Word1.TEST_CORE_Y_HIGH2_MASK)
-                << F.Word1.TEST_CORE_Y_HIGH2_OFFSET
+            | _p(z, F.Word1.TEST_CORE_XY_OFFSET, F.Word1.TEST_CORE_XY_MASK)
+            | _p(x, F.Word1.TEST_CORE_X_OFFSET, F.Word1.TEST_CORE_X_MASK)
+            | _p(
+                test_core_y_h2,
+                F.Word1.TEST_CORE_Y_HIGH2_OFFSET,
+                F.Word1.TEST_CORE_Y_HIGH2_MASK,
             )
         )
         w2 = (
-            (
-                (test_core_y_l4 & F.Word2.TEST_CORE_Y_LOW4_MASK)
-                << F.Word2.TEST_CORE_Y_LOW4_OFFSET
+            _p(
+                test_core_y_l4,
+                F.Word2.TEST_CORE_Y_LOW4_OFFSET,
+                F.Word2.TEST_CORE_Y_LOW4_MASK,
             )
-            | (
-                (core_reg["global_send"] & F.Word2.GLOBAL_SEND_MASK)
-                << F.Word2.GLOBAL_SEND_OFFSET
+            | _p(
+                core_reg["global_send"],
+                F.Word2.GLOBAL_SEND_OFFSET,
+                F.Word2.GLOBAL_SEND_MASK,
             )
-            | (
-                (core_reg["csc_accelerate"] & F.Word2.CSC_ACCELERATE_MASK)
-                << F.Word2.CSC_ACCELERATE_OFFSET
+            | _p(
+                core_reg["csc_accelerate"],
+                F.Word2.CSC_ACCELERATE_OFFSET,
+                F.Word2.CSC_ACCELERATE_MASK,
             )
-            | (
-                (core_reg["global_receive"] & F.Word2.GLOBAL_RECEIVE_MASK)
-                << F.Word2.GLOBAL_RECEIVE_OFFSET
+            | _p(
+                core_reg["global_receive"],
+                F.Word2.GLOBAL_RECEIVE_OFFSET,
+                F.Word2.GLOBAL_RECEIVE_MASK,
             )
-            | (
-                (core_reg["thread_number"] & F.Word2.THREAD_NUMBER_MASK)
-                << F.Word2.THREAD_NUMBER_OFFSET
+            | _p(
+                core_reg["thread_number"],
+                F.Word2.THREAD_NUMBER_OFFSET,
+                F.Word2.THREAD_NUMBER_MASK,
             )
-            | (
-                (core_reg["busy_cycle"] & F.Word2.BUSY_CYCLE_MASK)
-                << F.Word2.BUSY_CYCLE_OFFSET
+            | _p(
+                core_reg["busy_cycle"],
+                F.Word2.BUSY_CYCLE_OFFSET,
+                F.Word2.BUSY_CYCLE_MASK,
             )
-            | (
-                (core_reg["delay_cycle"] & F.Word2.DELAY_CYCLE_MASK)
-                << F.Word2.DELAY_CYCLE_OFFSET
+            | _p(
+                core_reg["delay_cycle"],
+                F.Word2.DELAY_CYCLE_OFFSET,
+                F.Word2.DELAY_CYCLE_MASK,
             )
-            | (
-                (core_reg["width_cycle"] & F.Word2.WIDTH_CYCLE_MASK)
-                << F.Word2.WIDTH_CYCLE_OFFSET
+            | _p(
+                core_reg["width_cycle"],
+                F.Word2.WIDTH_CYCLE_OFFSET,
+                F.Word2.WIDTH_CYCLE_MASK,
             )
         )
         w3 = (
-            (
-                (core_reg["tick_start"] & F.Word3.TICK_START_MASK)
-                << F.Word3.TICK_START_OFFSET
+            _p(
+                core_reg["tick_start"],
+                F.Word3.TICK_START_OFFSET,
+                F.Word3.TICK_START_MASK,
             )
-            | (
-                (core_reg["tick_duration"] & F.Word3.TICK_DURATION_MASK)
-                << F.Word3.TICK_DURATION_OFFSET
+            | _p(
+                core_reg["tick_duration"],
+                F.Word3.TICK_DURATION_OFFSET,
+                F.Word3.TICK_DURATION_MASK,
             )
-            | (
-                (core_reg["tick_initial"] & F.Word3.TICK_INITIAL_MASK)
-                << F.Word3.TICK_INITIAL_OFFSET
+            | _p(
+                core_reg["tick_initial"],
+                F.Word3.TICK_INITIAL_OFFSET,
+                F.Word3.TICK_INITIAL_MASK,
             )
         )
 
@@ -211,9 +251,13 @@ class OfflineFrameGenV2(FrameGenV2):
         F = Off_Cfg2_V2
         N_FRAME_PER_LUT_RAM = 256
 
-        assert potentials.size == activations.size
-        packages = np.zeros((N_FRAME_PER_LUT_RAM,), dtype=FRAME_DTYPE)
+        if potentials.size != activations.size:
+            raise ValueError(
+                f"potentials and activations should have the same size, "
+                f"but got {potentials.size} != {activations.size}"
+            )
 
+        packages = np.zeros((N_FRAME_PER_LUT_RAM,), dtype=FRAME_DTYPE)
         arr_pot_u64 = potentials.view(np.uint32).astype(FRAME_DTYPE)
         arr_act_u8 = activations.astype(np.uint8)
 
@@ -248,9 +292,51 @@ class OfflineFrameGenV2(FrameGenV2):
         full_attrs1: OfflineNeuFullAttrsV2Part1 | dict[str, Any] | None,
         full_attrs2: OfflineNeuFullAttrsV2Part2 | dict[str, Any] | None,
         folded_attrs1: OfflineNeuFoldedAttrsV2Part1 | dict[str, Any] | None,
-        folded_attrs2_: (list[OfflineNeuFoldedAttrsV2Part2] | list[dict[str, Any]]),
+        folded_attrs2_: list[OfflineNeuFoldedAttrsV2Part2] | list[dict[str, Any]],
     ) -> tuple[FrameArrayType, FrameArrayType, FrameArrayType]:
-        """Generate three packages of half, full & folded neuron attributes."""
+        """Generate config frame type III neuron packages in aggregate form.
+
+        This function is the aggregate entry for generating three possible package
+        groups under config frame type III:
+        - half neuron package
+        - full neuron package
+        - folded neuron package
+
+        For external callers that only need one package, prefer the dedicated
+        wrappers:
+        - `gen_config_frame3_pkg_half()`
+        - `gen_config_frame3_pkg_full()`
+        - `gen_config_frame3_pkg_folded()`
+
+        Accepted input combinations:
+        - Half only:
+          `full_attrs1` is provided, `full_attrs2` is `None`,
+          `folded_attrs1` is `None`, `folded_attrs2_` is empty.
+        - Full only:
+          `full_attrs1` and `full_attrs2` are both provided,
+          `folded_attrs1` is `None`, `folded_attrs2_` is empty.
+        - Folded only:
+          `full_attrs1` and `full_attrs2` are both `None`,
+          `folded_attrs1` is provided, `folded_attrs2_` is non-empty.
+        - Mixed:
+          half/full parameters and folded parameters may be provided together,
+          and the function will generate all requested package groups.
+
+        Invalid combinations:
+        - `full_attrs2` is provided while `full_attrs1` is missing
+        - `folded_attrs1` is provided while `folded_attrs2_` is empty
+        - `folded_attrs2_` is non-empty while `folded_attrs1` is missing
+
+        Returns:
+            A 3-tuple `(pkg_half_neu, pkg_full_neu, pkg_folded_neu)`.
+
+            - `pkg_half_neu`: encoded half-neuron package frames.
+            - `pkg_full_neu`: encoded full-neuron package frames.
+            - `pkg_folded_neu`: encoded folded-neuron package frames.
+
+            If a package type is not requested, the corresponding return value is
+            an empty `np.ndarray` with dtype `FRAME_DTYPE`.
+        """
         dest_info = OfflineNeuDestInfoV2.model_validate(
             dest_info, strict=True
         ).model_dump()
@@ -272,26 +358,80 @@ class OfflineFrameGenV2(FrameGenV2):
                 pkg_full_neu = OfflineFrameGenV2._gen_pkg_full_neu(
                     dest_info, full_attrs1, full_attrs2
                 )
+        elif full_attrs2 is not None:
+            raise ValueError("attributes of full neuron are incomplete, missing part1")
 
-        if folded_attrs1 is not None and len(folded_attrs2_) > 0:  # folded
-            folded_attrs1 = OfflineNeuFoldedAttrsV2Part1.model_validate(
-                folded_attrs1, strict=True
-            ).model_dump()
-            folded_attrs2 = [
-                OfflineNeuFoldedAttrsV2Part2.model_validate(
-                    attrs2, strict=True
+        if folded_attrs1 is not None:
+            if len(folded_attrs2_) == 0:
+                raise ValueError(
+                    "attributes of folded neuron are incomplete, missing part2"
+                )
+            else:  # folded
+                folded_attrs1 = OfflineNeuFoldedAttrsV2Part1.model_validate(
+                    folded_attrs1, strict=True
                 ).model_dump()
-                for attrs2 in folded_attrs2_
-            ]
-            pkg_folded_neu = OfflineFrameGenV2._gen_pkg_folded_neu(
-                folded_attrs1, *folded_attrs2
+                folded_attrs2 = [
+                    OfflineNeuFoldedAttrsV2Part2.model_validate(
+                        attrs2, strict=True
+                    ).model_dump()
+                    for attrs2 in folded_attrs2_
+                ]
+                pkg_folded_neu = OfflineFrameGenV2._gen_pkg_folded_neu(
+                    folded_attrs1, *folded_attrs2
+                )
+        elif len(folded_attrs2_) > 0:
+            raise ValueError(
+                "attributes of folded neuron are incomplete, missing part1"
             )
-        elif folded_attrs1 is None and len(folded_attrs2_) == 0:
-            pass
         else:
-            raise ValueError("attributes of folded neuron are incomplete")
+            pass  # empty
 
         return pkg_half_neu, pkg_full_neu, pkg_folded_neu
+
+    @staticmethod
+    def gen_config_frame3_pkg_half(
+        dest_info: OfflineNeuDestInfoV2 | dict[str, Any],
+        half_attrs: OfflineNeuHalfAttrsV2 | dict[str, Any],
+    ) -> FrameArrayType:
+        """Generate the half-neuron package of configuration frame type III."""
+        pkg_half_neu, _, _ = OfflineFrameGenV2.gen_config_frame3_pkg_neu(
+            dest_info, half_attrs, None, None, []
+        )
+        return pkg_half_neu
+
+    @staticmethod
+    def gen_config_frame3_pkg_full(
+        dest_info: OfflineNeuDestInfoV2 | dict[str, Any],
+        full_attrs1: OfflineNeuFullAttrsV2Part1 | dict[str, Any],
+        full_attrs2: OfflineNeuFullAttrsV2Part2 | dict[str, Any],
+    ) -> FrameArrayType:
+        """Generate the full-neuron package of configuration frame type III."""
+        _, pkg_full_neu, _ = OfflineFrameGenV2.gen_config_frame3_pkg_neu(
+            dest_info, full_attrs1, full_attrs2, None, []
+        )
+        return pkg_full_neu
+
+    @staticmethod
+    def gen_config_frame3_pkg_folded(
+        folded_attrs1: OfflineNeuFoldedAttrsV2Part1 | dict[str, Any],
+        folded_attrs2_: Sequence[OfflineNeuFoldedAttrsV2Part2 | dict[str, Any]],
+    ) -> FrameArrayType:
+        """Generate the folded-neuron package of configuration frame type III."""
+        if len(folded_attrs2_) == 0:
+            raise ValueError("attributes of folded neuron are incomplete")
+
+        folded_attrs1_dump = OfflineNeuFoldedAttrsV2Part1.model_validate(
+            folded_attrs1, strict=True
+        ).model_dump()
+        folded_attrs2_dump = [
+            OfflineNeuFoldedAttrsV2Part2.model_validate(
+                attrs2, strict=True
+            ).model_dump()
+            for attrs2 in folded_attrs2_
+        ]
+        return OfflineFrameGenV2._gen_pkg_folded_neu(
+            folded_attrs1_dump, *folded_attrs2_dump
+        )
 
     @staticmethod
     def _gen_pkg_half_neu(
@@ -301,69 +441,82 @@ class OfflineFrameGenV2(FrameGenV2):
         weight_skew_h11, weight_skew_l5 = bin_split(half_attrs["weight_skew"], 5, 11)
         # RAM[0][63:0]
         w1 = (
-            (
-                (weight_skew_l5 & F.Word1.WEIGHT_SKEW_LOW5_MASK)
-                << F.Word1.WEIGHT_SKEW_LOW5_OFFSET
+            _p(
+                weight_skew_l5,
+                F.Word1.WEIGHT_SKEW_LOW5_OFFSET,
+                F.Word1.WEIGHT_SKEW_LOW5_MASK,
             )
-            | (
-                (half_attrs["weight_address_start"] & F.Word1.WEIGHT_ADDRESS_START_MASK)
-                << F.Word1.WEIGHT_ADDRESS_START_OFFSET
+            | _p(
+                half_attrs["weight_address_start"],
+                F.Word1.WEIGHT_ADDRESS_START_OFFSET,
+                F.Word1.WEIGHT_ADDRESS_START_MASK,
             )
-            | (
-                (half_attrs["weight_address_end"] & F.Word1.WEIGHT_ADDRESS_END_MASK)
-                << F.Word1.WEIGHT_ADDRESS_END_OFFSET
+            | _p(
+                half_attrs["weight_address_end"],
+                F.Word1.WEIGHT_ADDRESS_END_OFFSET,
+                F.Word1.WEIGHT_ADDRESS_END_MASK,
             )
-            | (
-                (half_attrs["output_type"] & F.Word1.OUTPUT_TYPE_MASK)
-                << F.Word1.OUTPUT_TYPE_OFFSET
+            | _p(
+                half_attrs["output_type"],
+                F.Word1.OUTPUT_TYPE_OFFSET,
+                F.Word1.OUTPUT_TYPE_MASK,
             )
-            | (
-                (half_attrs["fold_type"] & F.Word1.FOLD_TYPE_MASK)
-                << F.Word1.FOLD_TYPE_OFFSET
+            | _p(
+                half_attrs["fold_type"],
+                F.Word1.FOLD_TYPE_OFFSET,
+                F.Word1.FOLD_TYPE_MASK,
             )
-            | (
-                (half_attrs["neuron_type"] & F.Word1.NEURON_TYPE_MASK)
-                << F.Word1.NEURON_TYPE_OFFSET
+            | _p(
+                half_attrs["neuron_type"],
+                F.Word1.NEURON_TYPE_OFFSET,
+                F.Word1.NEURON_TYPE_MASK,
             )
-            | ((half_attrs["vjt"] & F.Word1.VJT_MASK) << F.Word1.VJT_OFFSET)
+            | _p(half_attrs["vjt"], F.Word1.VJT_OFFSET, F.Word1.VJT_MASK)
         )
         # RAM[0][127:64]
         w2 = (
-            (
-                (dest_info["tick_relative"] & F.Word2.TICK_RELATIVE_MASK)
-                << F.Word2.TICK_RELATIVE_OFFSET
+            _p(
+                dest_info["tick_relative"],
+                F.Word2.TICK_RELATIVE_OFFSET,
+                F.Word2.TICK_RELATIVE_MASK,
             )
-            | (
-                (dest_info["addr_axon"] & F.Word2.ADDR_AXON_MASK)
-                << F.Word2.ADDR_AXON_OFFSET
+            | _p(
+                dest_info["addr_axon"], F.Word2.ADDR_AXON_OFFSET, F.Word2.ADDR_AXON_MASK
             )
-            | (
-                (dest_info["addr_core_xy"] & F.Word2.ADDR_CORE_XY_MASK)
-                << F.Word2.ADDR_CORE_XY_OFFSET
+            | _p(
+                dest_info["addr_core_xy"],
+                F.Word2.ADDR_CORE_XY_OFFSET,
+                F.Word2.ADDR_CORE_XY_MASK,
             )
-            | (
-                (dest_info["addr_core_x"] & F.Word2.ADDR_CORE_X_MASK)
-                << F.Word2.ADDR_CORE_X_OFFSET
+            | _p(
+                dest_info["addr_core_x"],
+                F.Word2.ADDR_CORE_X_OFFSET,
+                F.Word2.ADDR_CORE_X_MASK,
             )
-            | (
-                (dest_info["addr_core_y"] & F.Word2.ADDR_CORE_Y_MASK)
-                << F.Word2.ADDR_CORE_Y_OFFSET
+            | _p(
+                dest_info["addr_core_y"],
+                F.Word2.ADDR_CORE_Y_OFFSET,
+                F.Word2.ADDR_CORE_Y_MASK,
             )
-            | (
-                (dest_info["addr_copy_xy"] & F.Word2.ADDR_COPY_XY_MASK)
-                << F.Word2.ADDR_COPY_XY_OFFSET
+            | _p(
+                dest_info["addr_copy_xy"],
+                F.Word2.ADDR_COPY_XY_OFFSET,
+                F.Word2.ADDR_COPY_XY_MASK,
             )
-            | (
-                (dest_info["addr_copy_x"] & F.Word2.ADDR_COPY_X_MASK)
-                << F.Word2.ADDR_COPY_X_OFFSET
+            | _p(
+                dest_info["addr_copy_x"],
+                F.Word2.ADDR_COPY_X_OFFSET,
+                F.Word2.ADDR_COPY_X_MASK,
             )
-            | (
-                (dest_info["addr_copy_y"] & F.Word2.ADDR_COPY_Y_MASK)
-                << F.Word2.ADDR_COPY_Y_OFFSET
+            | _p(
+                dest_info["addr_copy_y"],
+                F.Word2.ADDR_COPY_Y_OFFSET,
+                F.Word2.ADDR_COPY_Y_MASK,
             )
-            | (
-                (weight_skew_h11 & F.Word2.WEIGHT_SKEW_HIGH11_MASK)
-                << F.Word2.WEIGHT_SKEW_HIGH11_OFFSET
+            | _p(
+                weight_skew_h11,
+                F.Word2.WEIGHT_SKEW_HIGH11_OFFSET,
+                F.Word2.WEIGHT_SKEW_HIGH11_MASK,
             )
         )
         return np.array([w1, w2], dtype=FRAME_DTYPE)
@@ -376,72 +529,81 @@ class OfflineFrameGenV2(FrameGenV2):
     ) -> FrameArrayType:
         F = Off_Cfg3_V2.Full
         pkg_half_neu = OfflineFrameGenV2._gen_pkg_half_neu(dest_info, full_attrs1)
-        thres_pos_h12, thres_pos_l20 = bin_split(full_attrs2["threshold_neg"], 20, 12)
+        thres_pos_h12, thres_pos_l20 = bin_split(full_attrs2["threshold_pos"], 20, 12)
         # RAM[1][63:0]
         w3 = (
-            (
-                (thres_pos_l20 & F.Word3.THRESHOLD_POS_LOW20_MASK)
-                << F.Word3.THRESHOLD_POS_LOW20_OFFSET
+            _p(
+                thres_pos_l20,
+                F.Word3.THRESHOLD_POS_LOW20_OFFSET,
+                F.Word3.THRESHOLD_POS_LOW20_MASK,
             )
-            | (
-                (full_attrs2["lateral_inhibition"] & F.Word3.LATERAL_INHIBITION_MASK)
-                << F.Word3.LATERAL_INHIBITION_OFFSET
+            | _p(
+                full_attrs2["lateral_inhibition"],
+                F.Word3.LATERAL_INHIBITION_OFFSET,
+                F.Word3.LATERAL_INHIBITION_MASK,
             )
-            | (
-                (full_attrs2["leak_multi_sequence"] & F.Word3.LEAK_MULTI_SEQUENCE_MASK)
-                << F.Word3.LEAK_MULTI_SEQUENCE_OFFSET
+            | _p(
+                full_attrs2["leak_multi_sequence"],
+                F.Word3.LEAK_MULTI_SEQUENCE_OFFSET,
+                F.Word3.LEAK_MULTI_SEQUENCE_MASK,
             )
-            | (
-                (full_attrs2["leak_multi_input"] & F.Word3.LEAK_MULTI_INPUT_MASK)
-                << F.Word3.LEAK_MULTI_INPUT_OFFSET
+            | _p(
+                full_attrs2["leak_multi_input"],
+                F.Word3.LEAK_MULTI_INPUT_OFFSET,
+                F.Word3.LEAK_MULTI_INPUT_MASK,
             )
-            | (
-                (full_attrs2["leak_multi_mode"] & F.Word3.LEAK_MULTI_MODE_MASK)
-                << F.Word3.LEAK_MULTI_MODE_OFFSET
+            | _p(
+                full_attrs2["leak_multi_mode"],
+                F.Word3.LEAK_MULTI_MODE_OFFSET,
+                F.Word3.LEAK_MULTI_MODE_MASK,
             )
-            | (
-                (full_attrs2["leak_add_mode"] & F.Word3.LEAK_ADD_MODE_MASK)
-                << F.Word3.LEAK_ADD_MODE_OFFSET
+            | _p(
+                full_attrs2["leak_add_mode"],
+                F.Word3.LEAK_ADD_MODE_OFFSET,
+                F.Word3.LEAK_ADD_MODE_MASK,
             )
-            | (
-                (full_attrs2["leak_tau"] & F.Word3.LEAK_TAU_MASK)
-                << F.Word3.LEAK_TAU_OFFSET
+            | _p(
+                full_attrs2["leak_tau"], F.Word3.LEAK_TAU_OFFSET, F.Word3.LEAK_TAU_MASK
             )
-            | ((full_attrs2["leak_v"] & F.Word3.LEAK_V_MASK) << F.Word3.LEAK_V_OFFSET)
-            | (
-                (full_attrs2["weight_compress"] & F.Word3.WEIGHT_COMPRESS_MASK)
-                << F.Word3.WEIGHT_COMPRESS_OFFSET
+            | _p(full_attrs2["leak_v"], F.Word3.LEAK_V_OFFSET, F.Word3.LEAK_V_MASK)
+            | _p(
+                full_attrs2["weight_compress"],
+                F.Word3.WEIGHT_COMPRESS_OFFSET,
+                F.Word3.WEIGHT_COMPRESS_MASK,
             )
-            | (
-                (full_attrs2["vjt_initial"] & F.Word3.VJT_INITIAL_MASK)
-                << F.Word3.VJT_INITIAL_OFFSET
+            | _p(
+                full_attrs2["vjt_initial"],
+                F.Word3.VJT_INITIAL_OFFSET,
+                F.Word3.VJT_INITIAL_MASK,
             )
         )
         # RAM[1][127:64]
         w4 = (
-            (
-                (full_attrs2["reset_mode"] & F.Word4.RESET_MODE_MASK)
-                << F.Word4.RESET_MODE_OFFSET
+            _p(
+                full_attrs2["reset_mode"],
+                F.Word4.RESET_MODE_OFFSET,
+                F.Word4.RESET_MODE_MASK,
             )
-            | (
-                (full_attrs2["reset_v"] & F.Word4.RESET_V_MASK)
-                << F.Word4.RESET_V_OFFSET
+            | _p(full_attrs2["reset_v"], F.Word4.RESET_V_OFFSET, F.Word4.RESET_V_MASK)
+            | _p(
+                full_attrs2["threshold_neg_mode"],
+                F.Word4.THRESHOLD_NEG_MODE_OFFSET,
+                F.Word4.THRESHOLD_NEG_MODE_MASK,
             )
-            | (
-                (full_attrs2["threshold_neg_mode"] & F.Word4.THRESHOLD_NEG_MODE_MASK)
-                << F.Word4.THRESHOLD_NEG_MODE_OFFSET
+            | _p(
+                full_attrs2["threshold_pos_mode"],
+                F.Word4.THRESHOLD_POS_MODE_OFFSET,
+                F.Word4.THRESHOLD_POS_MODE_MASK,
             )
-            | (
-                (full_attrs2["threshold_pos_mode"] & F.Word4.THRESHOLD_POS_MODE_MASK)
-                << F.Word4.THRESHOLD_POS_MODE_OFFSET
+            | _p(
+                full_attrs2["threshold_neg"],
+                F.Word4.THRESHOLD_NEG_OFFSET,
+                F.Word4.THRESHOLD_NEG_MASK,
             )
-            | (
-                (full_attrs2["threshold_neg"] & F.Word4.THRESHOLD_NEG_MASK)
-                << F.Word4.THRESHOLD_NEG_OFFSET
-            )
-            | (
-                (thres_pos_h12 & F.Word4.THRESHOLD_POS_HIGH12_MASK)
-                << F.Word4.THRESHOLD_POS_HIGH12_OFFSET
+            | _p(
+                thres_pos_h12,
+                F.Word4.THRESHOLD_POS_HIGH12_OFFSET,
+                F.Word4.THRESHOLD_POS_HIGH12_MASK,
             )
         )
         return np.r_[pkg_half_neu, w3, w4].astype(FRAME_DTYPE)
@@ -454,56 +616,69 @@ class OfflineFrameGenV2(FrameGenV2):
         fold_skew_y_h9, fold_skew_y_l2 = bin_split(folded_attrs1["fold_skew_y"], 2, 9)
         # RAM[0][63:0]
         w1 = (
-            (
-                (fold_skew_y_l2 & F.Word1.FOLD_SKEW_Y_LOW2_MASK)
-                << F.Word1.FOLD_SKEW_Y_LOW2_OFFSET
+            _p(
+                fold_skew_y_l2,
+                F.Word1.FOLD_SKEW_Y_LOW2_OFFSET,
+                F.Word1.FOLD_SKEW_Y_LOW2_MASK,
             )
-            | (
-                (folded_attrs1["fold_axon_xy"] & F.Word1.FOLD_AXON_XY_MASK)
-                << F.Word1.FOLD_AXON_XY_OFFSET
+            | _p(
+                folded_attrs1["fold_axon_xy"],
+                F.Word1.FOLD_AXON_XY_OFFSET,
+                F.Word1.FOLD_AXON_XY_MASK,
             )
-            | (
-                (folded_attrs1["fold_axon_x"] & F.Word1.FOLD_AXON_X_MASK)
-                << F.Word1.FOLD_AXON_X_OFFSET
+            | _p(
+                folded_attrs1["fold_axon_x"],
+                F.Word1.FOLD_AXON_X_OFFSET,
+                F.Word1.FOLD_AXON_X_MASK,
             )
-            | (
-                (folded_attrs1["fold_axon_y"] & F.Word1.FOLD_AXON_Y_MASK)
-                << F.Word1.FOLD_AXON_Y_OFFSET
+            | _p(
+                folded_attrs1["fold_axon_y"],
+                F.Word1.FOLD_AXON_Y_OFFSET,
+                F.Word1.FOLD_AXON_Y_MASK,
             )
-            | (
-                (folded_attrs1["fold_number"] & F.Word1.FOLD_NUMBER_MASK)
-                << F.Word1.FOLD_NUMBER_OFFSET
+            | _p(
+                folded_attrs1["fold_number"],
+                F.Word1.FOLD_NUMBER_OFFSET,
+                F.Word1.FOLD_NUMBER_MASK,
             )
         )
         # RAM[1][127:64]
         w2 = (
-            (
-                (folded_attrs1["fold_range_xy"] & F.Word2.FOLD_RANGE_XY_MASK)
-                << F.Word2.FOLD_RANGE_XY_OFFSET
+            _p(
+                folded_attrs1["fold_range_xy"],
+                F.Word2.FOLD_RANGE_XY_OFFSET,
+                F.Word2.FOLD_RANGE_XY_MASK,
             )
-            | (
-                (folded_attrs1["fold_range_x"] & F.Word2.FOLD_RANGE_X_MASK)
-                << F.Word2.FOLD_RANGE_X_OFFSET
+            | _p(
+                folded_attrs1["fold_range_x"],
+                F.Word2.FOLD_RANGE_X_OFFSET,
+                F.Word2.FOLD_RANGE_X_MASK,
             )
-            | (
-                (folded_attrs1["fold_range_y"] & F.Word2.FOLD_RANGE_Y_MASK)
-                << F.Word2.FOLD_RANGE_Y_OFFSET
+            | _p(
+                folded_attrs1["fold_range_y"],
+                F.Word2.FOLD_RANGE_Y_OFFSET,
+                F.Word2.FOLD_RANGE_Y_MASK,
             )
-            | (
-                (folded_attrs1["fold_skew_xy"] & F.Word2.FOLD_SKEW_XY_MASK)
-                << F.Word2.FOLD_SKEW_XY_OFFSET
+            | _p(
+                folded_attrs1["fold_skew_xy"],
+                F.Word2.FOLD_SKEW_XY_OFFSET,
+                F.Word2.FOLD_SKEW_XY_MASK,
             )
-            | (
-                (folded_attrs1["fold_skew_x"] & F.Word2.FOLD_SKEW_X_MASK)
-                << F.Word2.FOLD_SKEW_X_OFFSET
+            | _p(
+                folded_attrs1["fold_skew_x"],
+                F.Word2.FOLD_SKEW_X_OFFSET,
+                F.Word2.FOLD_SKEW_X_MASK,
             )
-            | (
-                (fold_skew_y_h9 & F.Word2.FOLD_SKEW_Y_HIGH9_MASK)
-                << F.Word2.FOLD_SKEW_Y_HIGH9_OFFSET
+            | _p(
+                fold_skew_y_h9,
+                F.Word2.FOLD_SKEW_Y_HIGH9_OFFSET,
+                F.Word2.FOLD_SKEW_Y_HIGH9_MASK,
             )
         )
 
-        assert len(folded_attrs2) > 0
+        if len(folded_attrs2) == 0:
+            raise ValueError("at least one folded neuron attrs part2 is required")
+
         v0 = np.array([item["fold_vjt_0"] for item in folded_attrs2], dtype=FRAME_DTYPE)
         v1 = np.array([item["fold_vjt_1"] for item in folded_attrs2], dtype=FRAME_DTYPE)
         v2 = np.array([item["fold_vjt_2"] for item in folded_attrs2], dtype=FRAME_DTYPE)
@@ -526,28 +701,24 @@ class OfflineFrameGenV2(FrameGenV2):
     @staticmethod
     def gen_config_frame3_weight_pkg(
         weight: np.ndarray,
-        weight_width: DataWidth | Literal[1, 2, 4, 8],
-        input_width: DataWidth | Literal[1, 2, 4, 8],
+        weight_width: DataWidthLE8Like,
+        input_width: DataWidthLE8Like,
         csc_compress: bool | CSCAccelerateMode = False,
     ) -> FrameArrayType:
         """Generate weight package for config frame type III."""
-        assert weight.ndim == 1
+        if weight.ndim != 1:
+            raise ValueError(
+                f"'weight' must be a 1D array, but got ndim={weight.ndim}."
+            )
 
         is_compress = csc_compress != CSCAccelerateMode.DISABLE
-        if isinstance(weight_width, DataWidth):
-            weight_width = 1 << weight_width.value
-        else:
-            weight_width = weight_width
-
-        if isinstance(input_width, DataWidth):
-            input_width = 1 << input_width.value
-        else:
-            input_width = input_width
+        norm_weight_width = _normalize_width_le8(weight_width, name="weight_width")
+        norm_input_width = _normalize_width_le8(input_width, name="input_width")
 
         if is_compress:
-            return weight_csc_pack(weight, weight_width, input_width)
+            return weight_csc_pack(weight, norm_weight_width, norm_input_width)
         else:
-            return weight_dense_pack(weight, weight_width)
+            return weight_dense_pack(weight, norm_weight_width)
 
     @staticmethod
     def gen_config_frame4(
@@ -556,8 +727,7 @@ class OfflineFrameGenV2(FrameGenV2):
         pkt_ncopy: AERPacketZXYCopy = AERPacketZXYCopy(),
         start_addr: int = 0,
     ):
-        # TODO
-        pass
+        raise NotImplementedError
 
     @staticmethod
     def gen_work_frame1(
@@ -587,14 +757,14 @@ class OfflineFrameGenV2(FrameGenV2):
         ts_low = ts & _mask(TS_WIDTH - 1)
 
         ts_ax_addr = (
-            (ts_msb << F.TIMESTEP_HIGH7_OFFSET)
+            _p(ts_msb, F.TIMESTEP_HIGH7_OFFSET, F.TIMESTEP_HIGH7_MASK)
             | (ts_low << (F.AXON_ADDR_OFFSET + AX_WIDTH))
             | ((ax & _mask(AX_WIDTH)) << F.AXON_ADDR_OFFSET)
         )
 
         mask = np.flatnonzero(_data)
         data_u8 = _data.astype(PAYLOAD_DATA_DTYPE)
-        frame_dest = get_frame_destV2(FH.WORK_TYPE1, pkt_offset, pkt_ncopy)
+        frame_dest = get_frame_dest_v2(FH.WORK_TYPE1, pkt_offset, pkt_ncopy)
         return (frame_dest + ts_ax_addr[mask] + data_u8[mask]).astype(FRAME_DTYPE)
 
     @staticmethod
@@ -633,9 +803,7 @@ class OfflineFrameGenV2(FrameGenV2):
 #         pass
 
 
-def weight_dense_pack(
-    weight: np.ndarray, weight_width: Literal[1, 2, 4, 8]
-) -> FrameArrayType:
+def weight_dense_pack(weight: np.ndarray, weight_width: DataWidthLE8) -> FrameArrayType:
     """Array uncompressed weights in RAM.
 
     weight[127:0] -> RAM[0][ 63: 0]
@@ -662,7 +830,9 @@ def weight_dense_pack(
 
 
 def weight_csc_pack(
-    weight: np.ndarray, weight_width: Literal[1, 2, 4, 8], input_width: Literal[1, 2, 4, 8]
+    weight: np.ndarray,
+    weight_width: DataWidthLE8,
+    input_width: DataWidthLE8,
 ) -> FrameArrayType:
     """Arrange compressed weights according to CSC format.
 
@@ -704,8 +874,7 @@ def weight_csc_pack(
     w_chunks = w_nonzero.reshape(n_chunk, n_nonzero_w_per_addr)
     # Index is no more than u16
 
-
-    # in csc pack, the indice stored in RAM is the bit offset of the non-zero weight, 
+    # in csc pack, the indice stored in RAM is the bit offset of the non-zero weight,
     # which is the original index multiplied by input_width.
     row_indices = row_indices * input_width
     idx_chunks = row_indices.reshape(n_chunk, n_nonzero_w_per_addr).astype(np.uint16)
@@ -743,10 +912,7 @@ def weight_csc_pack(
 
 
 def weight_dense_unpack(
-    frames: FrameArrayType,
-    weight_width: Literal[1, 2, 4, 8],
-    signed: bool,
-    original_size: int,
+    frames: FrameArrayType, weight_width: DataWidthLE8, signed: bool, original_size: int
 ) -> NDArray[np.int8 | np.uint8]:
     w_per_u64 = 64 // weight_width
     mask = _mask(weight_width)
@@ -767,7 +933,7 @@ def weight_dense_unpack(
 
 def weight_csc_unpack(
     frames: FrameArrayType,
-    weight_width: Literal[1, 2, 4, 8],
+    weight_width: DataWidthLE8,
     signed: bool,
     original_size: int,
 ) -> NDArray[np.int8 | np.uint8]:
@@ -776,7 +942,10 @@ def weight_csc_unpack(
     INDICES_ADDR_OFFSET = {1: 16, 2: 16, 4: 32, 8: 48}
     n_nonzero_w_per_addr = N_NONZERO_WEIGHT_PER_ADDR[weight_width]
 
-    assert frames.size % 2 == 0
+    if frames.size % 2 != 0:
+        raise ValueError(
+            f"'frames' length must be even for CSC unpack, but got {frames.size}."
+        )
 
     w_shifts = weight_width * np.arange(n_nonzero_w_per_addr, dtype=np.uint8)
     idx_shifts = INDICES_ADDR_OFFSET[weight_width] + 16 * np.arange(

--- a/paicorelib/framelib/utils.py
+++ b/paicorelib/framelib/utils.py
@@ -2,7 +2,7 @@ import warnings
 from collections.abc import Sequence
 from functools import wraps
 from pathlib import Path
-from typing import Any, Literal, SupportsIndex
+from typing import Any, Literal, SupportsIndex, overload
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -52,6 +52,23 @@ def header2type(header: FH) -> FT:
 def single_frame_header_check(frame: FRAME_DTYPE, expected: FH) -> bool:
     # Both for v1 & v2
     return (int(frame) >> FF.GENERAL_HEADER_OFFSET) & FF.GENERAL_HEADER_MASK == expected
+
+
+@overload
+def pack_field(value: int | np.generic, offset: int, mask: int) -> int: ...
+
+
+@overload
+def pack_field(value: np.ndarray, offset: int, mask: int) -> np.ndarray: ...
+
+
+def pack_field(
+    value: int | np.ndarray | np.generic, offset: int, mask: int
+) -> int | np.ndarray:
+    if isinstance(value, np.ndarray):
+        return (value & mask) << offset
+
+    return (int(value) & mask) << offset
 
 
 def framearray_header_check(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paicorelib"
-version = "2.0.0a3"
+version = "2.0.0b1"
 description = "Library of PAICORE"
 authors = [{ name = "Ziru Pan", email = "zrpan@stu.pku.edu.cn" }]
 license = { text = "GPL-3.0-or-later" }

--- a/tests/framelib/conftest.py
+++ b/tests/framelib/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from paicorelib.coordinate import CoordZXYOffset
+from paicorelib.routing_hexa import AERPacketZXYCopy
+from tests.utils import build_v2_packet_route
+
+
+@pytest.fixture
+def v2_packet_route() -> tuple[CoordZXYOffset, AERPacketZXYCopy]:
+    return build_v2_packet_route()

--- a/tests/framelib/test_base.py
+++ b/tests/framelib/test_base.py
@@ -9,6 +9,9 @@ from paicorelib.framelib.base import (
     FramePackage,
     FramePackageHeaderV2,
     FramePackagePayload,
+    FramePackagePayloadV2,
+    FrameV2,
+    get_frame_dest_v2,
 )
 from paicorelib.framelib.frame_defs import FFV2, FramePackageType
 from paicorelib.framelib.frame_defs import FrameHeader as FH
@@ -16,6 +19,8 @@ from paicorelib.framelib.frame_defs import FramePackageType as FPType
 from paicorelib.framelib.types import FRAME_DTYPE
 from paicorelib.routing_defs import _rid_unset
 from paicorelib.routing_hexa import AERPacketZXYCopy
+
+from ..utils import bit_field
 
 
 class TestFrameInstance:
@@ -35,20 +40,21 @@ class TestFrameInstance:
                 Coord(1, 2),
                 Coord(3, 4),
                 RId(5, 5),
-                np.random.randint(0, 128, size=(8,), dtype=FRAME_DTYPE),
+                "random_payload",
             ),
             (FH.WORK_TYPE2, Coord(3, 4), Coord(1, 2), RId(4, 4), FRAME_DTYPE(0)),
         ],
     )
-    def test_Frame_instance(self, header, chip_coord, core_coord, rid, payload):
+    def test_frame_instance(
+        self, fixed_rng, header, chip_coord, core_coord, rid, payload
+    ):
+        if isinstance(payload, str) and payload == "random_payload":
+            payload = fixed_rng.integers(0, 128, size=(8,), dtype=FRAME_DTYPE)
+
         f = Frame(chip_coord, core_coord, rid, payload, header=header)  # type: ignore
         assert len(f) == 1 if isinstance(payload, int) else payload.size
-
-        # check __str__
+        assert f.value.dtype == FRAME_DTYPE
         print(f)
-
-        # check .value
-        _ = f.value
 
     @pytest.mark.parametrize(
         "header, chip_coord, core_coord, rid, payload, packages",
@@ -59,9 +65,7 @@ class TestFrameInstance:
                 Coord(3, 4),
                 RId(5, 5),
                 FramePackagePayload(0, FPType.CONF_TESTOUT, 4 * 50),
-                np.random.randint(
-                    0, np.iinfo(np.uint64).max, size=(4 * 50,), dtype=FRAME_DTYPE
-                ),
+                "random_packages",
             ),
             (
                 FH.TEST_TYPE3,
@@ -69,21 +73,90 @@ class TestFrameInstance:
                 Coord(3, 4),
                 RId(5, 5),
                 FramePackagePayload(200, FPType.TESTIN, 4 * 100),
-                np.zeros(0),  # Empty package
+                np.zeros(0),
             ),
         ],
     )
-    def test_FramePackage_instance(
-        self, header, chip_coord, core_coord, rid, payload, packages
+    def test_frame_package_instance(
+        self, fixed_rng, header, chip_coord, core_coord, rid, payload, packages
     ):
+        if isinstance(packages, str) and packages == "random_packages":
+            packages = fixed_rng.integers(
+                0, np.iinfo(np.uint64).max, size=(4 * 50,), dtype=FRAME_DTYPE
+            )
+
         fp = FramePackage(chip_coord, core_coord, rid, payload, packages, header=header)  # type: ignore
         assert len(fp) == packages.size + 1
-
-        # check __str__
+        assert fp.value.dtype == FRAME_DTYPE
         print(fp)
 
-        # check .value
-        _ = fp.value
+
+class TestFramePackagePayloadV2:
+    def test_value(self):
+        payload = FramePackagePayloadV2(10, FramePackageType.CONF_TESTOUT, 99)
+
+        assert (
+            bit_field(
+                payload.value,
+                FFV2.GENERAL_PACKAGE_NEU_START_ADDR_OFFSET,
+                FFV2.GENERAL_PACKAGE_NEU_START_ADDR_MASK,
+            )
+            == 10
+        )
+        assert (
+            bit_field(
+                payload.value,
+                FFV2.GENERAL_PACKAGE_TYPE_OFFSET,
+                FFV2.GENERAL_PACKAGE_TYPE_MASK,
+            )
+            == FramePackageType.CONF_TESTOUT.value
+        )
+        assert (
+            bit_field(
+                payload.value,
+                FFV2.GENERAL_PACKAGE_NUM_OFFSET,
+                FFV2.GENERAL_PACKAGE_NUM_MASK,
+            )
+            == 99
+        )
+
+    @pytest.mark.parametrize(
+        "start_addr, n_package",
+        [
+            (FFV2.GENERAL_PACKAGE_NEU_START_ADDR_MASK + 1, 0),
+            (0, FFV2.GENERAL_PACKAGE_NUM_MASK + 1),
+            (-1, 0),
+            (0, -1),
+        ],
+    )
+    def test_rejects_out_of_range_values(self, start_addr, n_package):
+        with pytest.raises(ValueError):
+            FramePackagePayloadV2(start_addr, FramePackageType.CONF_TESTOUT, n_package)
+
+
+class TestFrameV2:
+    def test_value_matches_destination(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        frame = FrameV2(FH.CTRL_TYPE1, pkt_offset, pkt_ncopy, payload=123)
+
+        assert frame.frame_dest == get_frame_dest_v2(
+            FH.CTRL_TYPE1, pkt_offset, pkt_ncopy
+        )
+        assert frame.value.dtype == FRAME_DTYPE
+        assert frame.value.shape == (1,)
+        assert (
+            bit_field(
+                frame.value[0], FFV2.GENERAL_HEADER_OFFSET, FFV2.GENERAL_HEADER_MASK
+            )
+            == FH.CTRL_TYPE1.value
+        )
+        assert (
+            bit_field(
+                frame.value[0], FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK
+            )
+            == 123
+        )
+        assert "header:" in str(frame)
 
 
 class TestFramePackageHeaderV2:
@@ -98,36 +171,46 @@ class TestFramePackageHeaderV2:
         pkg_header = FramePackageHeaderV2.make_pkg_header(
             header, pkt_offset, pkt_ncopy, start_addr, pkg_type, n_package
         )
-        frames = pkg_header.value
+        frame = pkg_header.value[0]
 
         assert pkg_header.payload.n_package == n_package
-
-        oz = (
-            int(frames >> FFV2.GENERAL_CORE_XY_ADDR_OFFSET)
-            & FFV2.GENERAL_CORE_XY_ADDR_MASK
+        assert (
+            bit_field(
+                frame, FFV2.GENERAL_CORE_XY_ADDR_OFFSET, FFV2.GENERAL_CORE_XY_ADDR_MASK
+            )
+            == 33
         )
-        ox = (
-            int(frames >> FFV2.GENERAL_CORE_X_ADDR_OFFSET)
-            & FFV2.GENERAL_CORE_X_ADDR_MASK
+        assert (
+            bit_field(
+                frame, FFV2.GENERAL_CORE_X_ADDR_OFFSET, FFV2.GENERAL_CORE_X_ADDR_MASK
+            )
+            == 34
         )
-        oy = (
-            int(frames >> FFV2.GENERAL_CORE_Y_ADDR_OFFSET)
-            & FFV2.GENERAL_CORE_Y_ADDR_MASK
+        assert (
+            bit_field(
+                frame, FFV2.GENERAL_CORE_Y_ADDR_OFFSET, FFV2.GENERAL_CORE_Y_ADDR_MASK
+            )
+            == 3
         )
-        cz = (
-            int(frames >> FFV2.GENERAL_COPY_XY_ADDR_OFFSET)
-            & FFV2.GENERAL_COPY_XY_ADDR_MASK
+        assert (
+            bit_field(
+                frame, FFV2.GENERAL_COPY_XY_ADDR_OFFSET, FFV2.GENERAL_COPY_XY_ADDR_MASK
+            )
+            == 3
         )
-        cx = (
-            int(frames >> FFV2.GENERAL_COPY_X_ADDR_OFFSET)
-            & FFV2.GENERAL_COPY_X_ADDR_MASK
+        assert (
+            bit_field(
+                frame, FFV2.GENERAL_COPY_X_ADDR_OFFSET, FFV2.GENERAL_COPY_X_ADDR_MASK
+            )
+            == 34
         )
-        cy = (
-            int(frames >> FFV2.GENERAL_COPY_Y_ADDR_OFFSET)
-            & FFV2.GENERAL_COPY_Y_ADDR_MASK
+        assert (
+            bit_field(
+                frame, FFV2.GENERAL_COPY_Y_ADDR_OFFSET, FFV2.GENERAL_COPY_Y_ADDR_MASK
+            )
+            == 0
         )
-        assert (oz, ox, oy) == (33, 34, 3)
-        assert (cz, cx, cy) == (3, 34, 0)
 
         pkg_header.payload.n_package = 100
         assert pkg_header.payload.n_package == 100
+        assert "payload:" in str(pkg_header)

--- a/tests/framelib/test_frame_gen_v2.py
+++ b/tests/framelib/test_frame_gen_v2.py
@@ -1,27 +1,37 @@
 import contextlib
 import math
+from typing import Literal, cast
 
 import numpy as np
 import pytest
 
-from paicorelib.coordinate import CoordZXYOffset
 from paicorelib.core_defs import LCN_EX
-from paicorelib.core_defs_v2 import (
-    AddPotentialMode,
-    CSCAccelerateMode,
-    DataSign,
-    DataWidth,
-    PoolingMode,
-    SNNMode,
-    ZeroOutputMode,
-)
+from paicorelib.core_defs_v2 import CSCAccelerateMode, DataSign, DataWidth
 from paicorelib.core_model_v2 import OfflineCoreRegV2
 from paicorelib.framelib import FRAME_DTYPE
-from paicorelib.framelib.frame_defs import FFV2
+from paicorelib.framelib.frame_defs import FFV2, FramePackageType
 from paicorelib.framelib.frame_defs import FrameHeader as FH
-from paicorelib.framelib.frame_defs import OfflineConfigFrame2FormatV2 as Off_Cfg2_V2
-from paicorelib.framelib.frame_defs import OfflineWorkFrame1FormatV2 as Off_Work1_V2
+from paicorelib.framelib.frame_defs import (
+    OfflineConfigFrame1FormatV2 as Off_Cfg1_V2,
+)
+from paicorelib.framelib.frame_defs import (
+    OfflineConfigFrame2FormatV2 as Off_Cfg2_V2,
+)
+from paicorelib.framelib.frame_defs import (
+    OfflineConfigFrame3FormatV2 as Off_Cfg3_V2,
+)
+from paicorelib.framelib.frame_defs import (
+    OfflineControlFrame1FormatV2 as Off_Ctrl1_V2,
+)
+from paicorelib.framelib.frame_defs import (
+    OfflineControlFrame3FormatV2 as Off_Ctrl3_V2,
+)
+from paicorelib.framelib.frame_defs import (
+    OfflineWorkFrame1FormatV2 as Off_Work1_V2,
+)
 from paicorelib.framelib.frame_gen_v2 import (
+    DataWidthLE8Like,
+    FrameGenV2,
     OfflineFrameGenV2,
     weight_csc_pack,
     weight_csc_unpack,
@@ -33,7 +43,7 @@ from paicorelib.framelib.types import (
     LUT_POTENTIAL_DTYPE,
     FrameArrayType,
 )
-from paicorelib.framelib.utils import print_frame, single_frame_header_check
+from paicorelib.framelib.utils import single_frame_header_check
 from paicorelib.neuron_defs import ResetMode
 from paicorelib.neuron_defs_v2 import (
     FoldType,
@@ -54,15 +64,27 @@ from paicorelib.neuron_model_v2 import (
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
-    OfflineNeuHalfAttrsV2,
 )
-from paicorelib.routing_hexa import AERPacketZXYCopy
 from paicorelib.utils import _mask
-from tests.utils import gen_random_array
+from tests.utils import (
+    bit_field,
+    build_v2_core_reg_params,
+    build_v2_dest_info_params,
+    build_v2_folded_attrs_part1_params,
+    build_v2_folded_attrs_part2_params,
+    build_v2_full_attrs_part2_params,
+    build_v2_half_attrs_params,
+    build_v2_weight_array,
+    gen_random_array,
+)
+
+WidthBitsLE8 = Literal[1, 2, 4, 8]
 
 
 def parse_package_header(frames: FrameArrayType) -> tuple[int, int, int]:
-    payload = (frames[0] >> FFV2.GENERAL_PAYLOAD_OFFSET) & FFV2.GENERAL_PAYLOAD_MASK
+    payload = bit_field(
+        frames[0], FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK
+    )
     pkg_type = (
         payload >> FFV2.GENERAL_PACKAGE_TYPE_OFFSET
     ) & FFV2.GENERAL_PACKAGE_TYPE_MASK
@@ -72,256 +94,550 @@ def parse_package_header(frames: FrameArrayType) -> tuple[int, int, int]:
     n_package = (
         payload >> FFV2.GENERAL_PACKAGE_NUM_OFFSET
     ) & FFV2.GENERAL_PACKAGE_NUM_MASK
-
     return pkg_type, start_addr, n_package
 
 
 def extract_lut_from_cf2(cf2: FrameArrayType, act_dtype: LUT_ACTIVATION_DTYPE):
-    F = Off_Cfg2_V2
     assert cf2.size == 257
     assert single_frame_header_check(cf2[0], FH.CONFIG_TYPE2)
 
     lut = cf2[1:]
-    arr_pot = ((lut >> F.POTENTIAL_OFFSET) & F.POTENTIAL_MASK).astype(
-        LUT_POTENTIAL_DTYPE
-    )
-    arr_act = ((lut >> F.ACTIVATION_OFFSET) & F.ACTIVATION_MASK).astype(act_dtype)
+    arr_pot = (
+        (lut >> Off_Cfg2_V2.POTENTIAL_OFFSET) & Off_Cfg2_V2.POTENTIAL_MASK
+    ).astype(LUT_POTENTIAL_DTYPE)
+    arr_act = (
+        (lut >> Off_Cfg2_V2.ACTIVATION_OFFSET) & Off_Cfg2_V2.ACTIVATION_MASK
+    ).astype(act_dtype)
     return arr_pot, arr_act
 
 
+def normalize_width_bits(value: DataWidthLE8Like) -> WidthBitsLE8:
+    width_bits = (1 << value.value) if isinstance(value, DataWidth) else int(value)
+    return cast(WidthBitsLE8, width_bits)
+
+
+def validated_dump(model_cls, params):
+    return model_cls.model_validate(params, strict=True).model_dump()
+
+
 class TestFrameGenV2:
-    def test_make_package(self):
-        pass
+    def test_make_package(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        packages = np.array([11, 22, 33], dtype=FRAME_DTYPE)
+
+        frames = FrameGenV2.make_package(
+            FH.CONFIG_TYPE2, pkt_offset, pkt_ncopy, 7, packages
+        )
+
+        assert frames.dtype == FRAME_DTYPE
+        assert frames.shape == (4,)
+        assert single_frame_header_check(frames[0], FH.CONFIG_TYPE2)
+        assert parse_package_header(frames) == (
+            FramePackageType.CONF_TESTOUT.value,
+            7,
+            3,
+        )
+        assert np.array_equal(frames[1:], packages)
 
 
 class TestOfflineFrameGenV2:
-    # def _parse_frame(self, frame):
-    #     """Helper to unpack a standard frame (Header/Addr/Payload)."""
-    #     val = int(frame)
-    #     header = (val >> FFV2.GENERAL_HEADER_OFFSET) & FFV2.GENERAL_HEADER_MASK
-    #     core_addr = (val >> FFV2.GENERAL_CORE_ADDR_OFFSET) & FFV2.GENERAL_CORE_ADDR_MASK
-    #     copy_addr = (val >> FFV2.GENERAL_COPY_ADDR_OFFSET) & FFV2.GENERAL_COPY_ADDR_MASK
-    #     payload = val & FFV2.GENERAL_PAYLOAD_MASK
-    #     return header, core_addr, copy_addr, payload
-
-    # def test_gen_data_frame(self):
-    #     """Test Work Frame Type 1 with dynamic widths."""
-    #     core, copy = 0x10, 0x20
-    #     ts, axon, data = 10, 0x100, 0x55
-
-    #     # Define dynamic widths (must sum to 17 for time + axon)
-    #     t_w, a_w, d_w = 7, 10, 8
-
-    #     frames = OfflineFrameGenV2.gen_data_frame(
-    #         core, copy, ts, axon, data, time_width=t_w, axon_width=a_w, data_width=d_w
-    #     )
-    #     assert frames.shape == (1,)
-
-    #     hd, c, cp, pl = self._parse_frame(frames[0])
-    #     assert hd == FH.WORK_TYPE1
-    #     assert c == core
-    #     assert cp == copy
-
-    #     # Calculate expected payload manually
-    #     # Logic: mixed = (ts << axon_width) | axon
-    #     # Layout: MSB(1bit) at 60 | Low(16bits) at 8 | Data at 0
-    #     mixed = (ts << a_w) | axon
-    #     msb = (mixed >> 16) & 1
-    #     low = mixed & 0xFFFF
-
-    #     expected_payload = (msb << 60) | (low << 8) | data
-    #     assert pl == expected_payload
-
-    # def test_gen_vjt_frame(self):
-    #     """Test Work Frame Type 2 with dynamic widths."""
-    #     core, copy = 0x10, 0x20
-    #     ts, axon, vjt = 5, 0x200, 0xAA
-
-    #     t_w, a_w, v_w = 7, 10, 8
-
-    #     frames = OfflineFrameGenV2.gen_vjt_frame(
-    #         core, copy, ts, axon, vjt, time_width=t_w, axon_width=a_w, vjt_width=v_w
-    #     )
-    #     assert frames.shape == (1,)
-
-    #     hd, c, cp, pl = self._parse_frame(frames[0])
-    #     assert hd == FH.WORK_TYPE2
-
-    #     mixed = (ts << a_w) | axon
-    #     msb = (mixed >> 16) & 1
-    #     low = mixed & 0xFFFF
-
-    #     # VJT at offset 0
-    #     expected_payload = (msb << 60) | (low << 8) | vjt
-    #     assert pl == expected_payload
-
-    def test_cf1(self):
-        core_reg = OfflineCoreRegV2(
-            name="core_reg",
-            snn_ann=SNNMode.SNN,
-            max_pooling=PoolingMode.AVERAGE,
-            add_potential=AddPotentialMode.NORMAL,
-            zero_output=ZeroOutputMode.DISABLE,
-            input_sign=DataSign.SIGNED,
-            input_width=DataWidth.WIDTH_8BIT,
-            output_sign=DataSign.SIGNED,
-            output_width=DataWidth.WIDTH_8BIT,
-            weight_sign=DataSign.SIGNED,
-            weight_width=DataWidth.WIDTH_8BIT,
-            lcn=LCN_EX.LCN_8X,
-            target_lcn=LCN_EX.LCN_8X,
-            axon_skew=0,
-            neuron_number=200,
-            test_core_xy=5,
-            test_core_x=0,
-            test_core_y=0,
-            global_send=0b100_0000,
-            csc_accelerate=CSCAccelerateMode.ENABLE,
-            global_receive=0b001_0000,
-            thread_number=1,
-            busy_cycle=2,
-            delay_cycle=2,
-            width_cycle=2,
-            tick_start=1,
+    def test_cf1(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        core_reg = OfflineCoreRegV2.model_validate(
+            build_v2_core_reg_params(
+                name="core_reg",
+                input_width=DataWidth.WIDTH_8BIT,
+                output_width=DataWidth.WIDTH_8BIT,
+                weight_sign=DataSign.SIGNED,
+                weight_width=DataWidth.WIDTH_8BIT,
+                lcn=LCN_EX.LCN_8X,
+                target_lcn=LCN_EX.LCN_8X,
+                neuron_number=200,
+                test_core_xy=5,
+                global_send=0b100_0000,
+                csc_accelerate=CSCAccelerateMode.ENABLE,
+                global_receive=0b001_0000,
+                busy_cycle=2,
+                tick_start=1,
+            ),
+            strict=True,
         )
 
-        frames = OfflineFrameGenV2.gen_config_frame1(
-            CoordZXYOffset(1, 1, 1), core_reg, AERPacketZXYCopy(0, 1, -1), 0
-        )
+        frames = OfflineFrameGenV2.gen_config_frame1(pkt_offset, core_reg, pkt_ncopy, 0)
+
         assert frames.dtype == FRAME_DTYPE
-        assert frames.size == 1 + 3
+        assert frames.size == 4
+        assert parse_package_header(frames) == (
+            FramePackageType.CONF_TESTOUT.value,
+            0,
+            3,
+        )
+        assert (
+            bit_field(
+                frames[1],
+                Off_Cfg1_V2.Word1.TARGET_LCN_OFFSET,
+                Off_Cfg1_V2.Word1.TARGET_LCN_MASK,
+            )
+            == LCN_EX.LCN_8X.value
+        )
+        assert (
+            bit_field(
+                frames[2],
+                Off_Cfg1_V2.Word2.CSC_ACCELERATE_OFFSET,
+                Off_Cfg1_V2.Word2.CSC_ACCELERATE_MASK,
+            )
+            == CSCAccelerateMode.ENABLE.value
+        )
+        assert (
+            bit_field(
+                frames[3],
+                Off_Cfg1_V2.Word3.TICK_START_OFFSET,
+                Off_Cfg1_V2.Word3.TICK_START_MASK,
+            )
+            == 1
+        )
 
-    @pytest.mark.parametrize("random", [True, False])
+    @pytest.mark.parametrize("use_random_lut", [True, False])
     @pytest.mark.parametrize("act_dtype", [np.uint8, np.int8])
-    def test_cf2(self, random, act_dtype):
-        if random:
-            arr_pot = np.arange(-128, 128, dtype=LUT_POTENTIAL_DTYPE)
-            if act_dtype == np.uint8:
-                arr_act = np.ones((256,), dtype=act_dtype)
-            else:
-                arr_act = np.full((256,), -1, dtype=act_dtype)
-        else:
+    def test_cf2(self, v2_packet_route, use_random_lut, act_dtype):
+        pkt_offset, _ = v2_packet_route
+        if use_random_lut:
             arr_pot = gen_random_array((256,), dtype=LUT_POTENTIAL_DTYPE)
             arr_act = gen_random_array((256,), dtype=act_dtype)
+        else:
+            arr_pot = np.arange(-128, 128, dtype=LUT_POTENTIAL_DTYPE)
+            arr_act = (
+                np.ones((256,), dtype=act_dtype)
+                if act_dtype == np.uint8
+                else np.full((256,), -1, dtype=act_dtype)
+            )
 
-        frames = OfflineFrameGenV2.gen_config_frame2(
-            CoordZXYOffset(1, 1, 1), arr_pot, arr_act
-        )
-        assert frames.size == 1 + 256
+        frames = OfflineFrameGenV2.gen_config_frame2(pkt_offset, arr_pot, arr_act)
+
+        assert frames.size == 257
 
         arr_pot2, arr_act2 = extract_lut_from_cf2(frames, act_dtype)
         assert np.array_equal(arr_pot, arr_pot2)
         assert np.array_equal(arr_act, arr_act2)
 
-    def test_gen_config_frame3_pkg_header(self):
-        frames = OfflineFrameGenV2.gen_config_frame3_pkg_header(
-            CoordZXYOffset(1, 1, 1), 0, 0
-        )
-        assert frames.dtype == FRAME_DTYPE
-        assert frames.size == 1
+    def test_cf2_rejects_mismatched_lut_size(self, v2_packet_route):
+        pkt_offset, _ = v2_packet_route
+        arr_pot = np.arange(255, dtype=LUT_POTENTIAL_DTYPE)
+        arr_act = np.arange(256, dtype=np.uint8)
 
-    def test_gen_pkg_half_neu(self):
-        dest_info = OfflineNeuDestInfoV2(
-            tick_relative=0,
-            addr_axon=1,
-            addr_core_xy=0,
-            addr_core_x=1,
-            addr_core_y=-1,
-            addr_copy_xy=1,
-            addr_copy_x=1,
-            addr_copy_y=1,
+        with pytest.raises(ValueError, match="same size"):
+            OfflineFrameGenV2.gen_config_frame2(pkt_offset, arr_pot, arr_act)
+
+    @pytest.mark.parametrize("n_package", [0, 1, 100, 1000, 8000])
+    def test_gen_config_frame3_pkg_header(self, v2_packet_route, n_package):
+        pkt_offset, _ = v2_packet_route
+        frames = OfflineFrameGenV2.gen_config_frame3_pkg_header(
+            pkt_offset, 12, n_package
         )
-        half_attrs = OfflineNeuHalfAttrsV2(
-            weight_skew=0,
-            weight_address_start=0,
-            weight_address_end=128,
-            fold_type=FoldType.UNFOLDED,
-            neuron_type=NeuronType.HALF,
-            output_type=OutputType.VALUE,
+
+        assert frames.dtype == FRAME_DTYPE
+        assert frames.shape == (1,)
+        assert single_frame_header_check(frames[0], FH.CONFIG_TYPE3)
+        assert parse_package_header(frames) == (
+            FramePackageType.CONF_TESTOUT.value,
+            12,
+            n_package,
         )
+
+    def test_gen_pkg_half_neu_fields(self):
+        dest_info = build_v2_dest_info_params(
+            tick_relative=7,
+            addr_axon=0x1AB,
+            addr_core_xy=-1,
+            addr_core_x=2,
+            addr_core_y=-3,
+            addr_copy_xy=4,
+            addr_copy_x=5,
+            addr_copy_y=-6,
+        )
+        half_attrs = build_v2_half_attrs_params(
+            weight_skew=0x6A5,
+            weight_address_start=0x123,
+            weight_address_end=0x456,
+            output_type=OutputType.POTENTIAL,
+            fold_type=FoldType.FOLDED,
+            neuron_type=NeuronType.FULL,
+            vjt=0x12345678,
+        )
+
+        dest_info_dump = validated_dump(OfflineNeuDestInfoV2, dest_info)
+        half_attrs_dump = validated_dump(OfflineNeuFullAttrsV2Part1, half_attrs)
 
         pkg_half_neu = OfflineFrameGenV2._gen_pkg_half_neu(
-            dest_info.model_dump(), half_attrs.model_dump()
+            dest_info_dump, half_attrs_dump
         )
-        assert pkg_half_neu.dtype == FRAME_DTYPE
-        assert pkg_half_neu.size == 2
 
-    def test_gen_pkg_full_neu(self):
-        dest_info = OfflineNeuDestInfoV2(
-            tick_relative=0,
-            addr_axon=1,
-            addr_core_xy=0,
-            addr_core_x=1,
-            addr_core_y=-1,
-            addr_copy_xy=1,
-            addr_copy_x=1,
-            addr_copy_y=1,
+        assert pkg_half_neu.dtype == FRAME_DTYPE
+        assert pkg_half_neu.shape == (2,)
+        assert bit_field(
+            pkg_half_neu[0],
+            Off_Cfg3_V2.Full.Word1.WEIGHT_SKEW_LOW5_OFFSET,
+            Off_Cfg3_V2.Full.Word1.WEIGHT_SKEW_LOW5_MASK,
+        ) == (half_attrs["weight_skew"] & Off_Cfg3_V2.Full.Word1.WEIGHT_SKEW_LOW5_MASK)
+        assert bit_field(
+            pkg_half_neu[1],
+            Off_Cfg3_V2.Full.Word2.WEIGHT_SKEW_HIGH11_OFFSET,
+            Off_Cfg3_V2.Full.Word2.WEIGHT_SKEW_HIGH11_MASK,
+        ) == (half_attrs["weight_skew"] >> 5)
+        assert (
+            bit_field(
+                pkg_half_neu[0],
+                Off_Cfg3_V2.Full.Word1.WEIGHT_ADDRESS_START_OFFSET,
+                Off_Cfg3_V2.Full.Word1.WEIGHT_ADDRESS_START_MASK,
+            )
+            == half_attrs["weight_address_start"]
         )
-        full_attrs1 = OfflineNeuFullAttrsV2Part1(
-            weight_skew=0,
-            weight_address_start=0,
-            weight_address_end=128,
+        assert (
+            bit_field(
+                pkg_half_neu[0],
+                Off_Cfg3_V2.Full.Word1.WEIGHT_ADDRESS_END_OFFSET,
+                Off_Cfg3_V2.Full.Word1.WEIGHT_ADDRESS_END_MASK,
+            )
+            == half_attrs["weight_address_end"]
+        )
+        assert bit_field(
+            pkg_half_neu[1],
+            Off_Cfg3_V2.Full.Word2.ADDR_CORE_Y_OFFSET,
+            Off_Cfg3_V2.Full.Word2.ADDR_CORE_Y_MASK,
+        ) == (dest_info["addr_core_y"] & Off_Cfg3_V2.Full.Word2.ADDR_CORE_Y_MASK)
+
+    def test_gen_pkg_full_neu_fields(self):
+        dest_info = build_v2_dest_info_params(
+            tick_relative=9,
+            addr_axon=17,
+            addr_core_xy=1,
+            addr_core_x=2,
+            addr_core_y=3,
+            addr_copy_xy=4,
+            addr_copy_x=5,
+            addr_copy_y=6,
+        )
+        full_attrs1 = build_v2_half_attrs_params(
+            weight_skew=0x123,
+            weight_address_start=10,
+            weight_address_end=20,
+            output_type=OutputType.POTENTIAL,
             fold_type=FoldType.UNFOLDED,
-            neuron_type=NeuronType.HALF,
-            output_type=OutputType.VALUE,
+            neuron_type=NeuronType.FULL,
+            vjt=0x2468ACE,
         )
-        full_attrs2 = OfflineNeuFullAttrsV2Part2(
+        full_attrs2 = build_v2_full_attrs_part2_params(
             reset_mode=ResetMode.MODE_LINEAR,
-            reset_v=0,
-            threshold_neg_mode=ThresholdNegMode.FIRE,
-            threshold_pos_mode=ThresholdPosMode.FIRE,
-            threshold_neg=0,
-            threshold_pos=1,
-            lateral_inhibition=LateralInhibitionMode.DISABLE,
+            reset_v=-123,
+            threshold_neg_mode=ThresholdNegMode.FLOOR,
+            threshold_pos_mode=ThresholdPosMode.CEILING,
+            threshold_neg=-0x12345,
+            threshold_pos=0x12345678,
+            lateral_inhibition=LateralInhibitionMode.ENABLE,
             leak_multi_sequence=LeakMultiComparisonOrder.AFTER_COMPARE,
             leak_multi_input=LeakMultiInputMode.ENABLE,
             leak_multi_mode=LeakMultiMode.ENABLE,
-            leak_add_mode=LeakAddMode.FORWARD,
-            leak_tau=2,
-            leak_v=0,
+            leak_add_mode=LeakAddMode.BACKWARD,
+            leak_tau=17,
+            leak_v=-0x1234,
             weight_compress=WeightCompressType.SPARSE,
+            vjt_initial=0x345,
         )
+
+        dest_info_dump = validated_dump(OfflineNeuDestInfoV2, dest_info)
+        full_attrs1_dump = validated_dump(OfflineNeuFullAttrsV2Part1, full_attrs1)
+        full_attrs2_dump = validated_dump(OfflineNeuFullAttrsV2Part2, full_attrs2)
 
         pkg_full_neu = OfflineFrameGenV2._gen_pkg_full_neu(
-            dest_info.model_dump(), full_attrs1.model_dump(), full_attrs2.model_dump()
+            dest_info_dump, full_attrs1_dump, full_attrs2_dump
         )
+
+        threshold_pos = (
+            bit_field(
+                pkg_full_neu[3],
+                Off_Cfg3_V2.Full.Word4.THRESHOLD_POS_HIGH12_OFFSET,
+                Off_Cfg3_V2.Full.Word4.THRESHOLD_POS_HIGH12_MASK,
+            )
+            << 20
+        ) | bit_field(
+            pkg_full_neu[2],
+            Off_Cfg3_V2.Full.Word3.THRESHOLD_POS_LOW20_OFFSET,
+            Off_Cfg3_V2.Full.Word3.THRESHOLD_POS_LOW20_MASK,
+        )
+
         assert pkg_full_neu.dtype == FRAME_DTYPE
-        assert pkg_full_neu.size == 4
-
-    def test_gen_pkg_folded_neu(self):
-        attrs1 = OfflineNeuFoldedAttrsV2Part1(
-            fold_range_xy=1,
-            fold_range_x=1,
-            fold_range_y=1,
-            fold_skew_xy=0,
-            fold_skew_x=1,
-            fold_skew_y=1,
-            fold_axon_xy=1,
-            fold_axon_x=1,
-            fold_axon_y=0,
-            fold_number=1,
+        assert pkg_full_neu.shape == (4,)
+        assert threshold_pos == full_attrs2["threshold_pos"]
+        assert bit_field(
+            pkg_full_neu[3],
+            Off_Cfg3_V2.Full.Word4.THRESHOLD_NEG_OFFSET,
+            Off_Cfg3_V2.Full.Word4.THRESHOLD_NEG_MASK,
+        ) == (full_attrs2["threshold_neg"] & Off_Cfg3_V2.Full.Word4.THRESHOLD_NEG_MASK)
+        assert bit_field(
+            pkg_full_neu[3],
+            Off_Cfg3_V2.Full.Word4.RESET_V_OFFSET,
+            Off_Cfg3_V2.Full.Word4.RESET_V_MASK,
+        ) == (full_attrs2["reset_v"] & Off_Cfg3_V2.Full.Word4.RESET_V_MASK)
+        assert bit_field(
+            pkg_full_neu[2],
+            Off_Cfg3_V2.Full.Word3.LEAK_V_OFFSET,
+            Off_Cfg3_V2.Full.Word3.LEAK_V_MASK,
+        ) == (full_attrs2["leak_v"] & Off_Cfg3_V2.Full.Word3.LEAK_V_MASK)
+        assert (
+            bit_field(
+                pkg_full_neu[2],
+                Off_Cfg3_V2.Full.Word3.WEIGHT_COMPRESS_OFFSET,
+                Off_Cfg3_V2.Full.Word3.WEIGHT_COMPRESS_MASK,
+            )
+            == WeightCompressType.SPARSE.value
         )
 
-        attrs2_1 = OfflineNeuFoldedAttrsV2Part2(
-            fold_vjt_3=100, fold_vjt_2=200, fold_vjt_1=300, fold_vjt_0=400
+    def test_gen_pkg_folded_neu_fields(self):
+        attrs1 = build_v2_folded_attrs_part1_params(
+            fold_range_xy=2,
+            fold_range_x=3,
+            fold_range_y=4,
+            fold_skew_xy=5,
+            fold_skew_x=6,
+            fold_skew_y=0x155,
+            fold_axon_xy=7,
+            fold_axon_x=8,
+            fold_axon_y=9,
+            fold_number=24,
         )
-        attrs2_2 = OfflineNeuFoldedAttrsV2Part2(
-            fold_vjt_3=0, fold_vjt_2=1, fold_vjt_1=2, fold_vjt_0=3
+        attrs2_1 = build_v2_folded_attrs_part2_params(
+            fold_vjt_3=100,
+            fold_vjt_2=200,
+            fold_vjt_1=300,
+            fold_vjt_0=400,
         )
+        attrs2_2 = build_v2_folded_attrs_part2_params(
+            fold_vjt_3=10,
+            fold_vjt_2=20,
+            fold_vjt_1=30,
+            fold_vjt_0=40,
+        )
+
+        attrs1_dump = validated_dump(OfflineNeuFoldedAttrsV2Part1, attrs1)
+        attrs2_1_dump = validated_dump(OfflineNeuFoldedAttrsV2Part2, attrs2_1)
+        attrs2_2_dump = validated_dump(OfflineNeuFoldedAttrsV2Part2, attrs2_2)
 
         pkg_folded_neu = OfflineFrameGenV2._gen_pkg_folded_neu(
-            attrs1.model_dump(), *[attrs2_1.model_dump(), attrs2_2.model_dump()]
+            attrs1_dump, attrs2_1_dump, attrs2_2_dump
         )
-        assert pkg_folded_neu.dtype == FRAME_DTYPE
-        assert pkg_folded_neu.size == 2 + 2 * 2
 
-    def test_gen_config_frame3_weight_pkg(self, fixed_rng):
-        weight = fixed_rng.integers(-128, 127, size=(32,))
+        assert pkg_folded_neu.dtype == FRAME_DTYPE
+        assert pkg_folded_neu.shape == (6,)
+        assert bit_field(
+            pkg_folded_neu[0],
+            Off_Cfg3_V2.Fold.Word1.FOLD_SKEW_Y_LOW2_OFFSET,
+            Off_Cfg3_V2.Fold.Word1.FOLD_SKEW_Y_LOW2_MASK,
+        ) == (attrs1["fold_skew_y"] & Off_Cfg3_V2.Fold.Word1.FOLD_SKEW_Y_LOW2_MASK)
+        assert bit_field(
+            pkg_folded_neu[1],
+            Off_Cfg3_V2.Fold.Word2.FOLD_SKEW_Y_HIGH9_OFFSET,
+            Off_Cfg3_V2.Fold.Word2.FOLD_SKEW_Y_HIGH9_MASK,
+        ) == (attrs1["fold_skew_y"] >> 2)
+        assert (
+            bit_field(
+                pkg_folded_neu[2],
+                Off_Cfg3_V2.Fold.Word3.FOLD_VJT_0_OFFSET,
+                Off_Cfg3_V2.Fold.Word3.FOLD_VJT_0_MASK,
+            )
+            == attrs2_1["fold_vjt_0"]
+        )
+        assert (
+            bit_field(
+                pkg_folded_neu[3],
+                Off_Cfg3_V2.Fold.Word4.FOLD_VJT_3_OFFSET,
+                Off_Cfg3_V2.Fold.Word4.FOLD_VJT_3_MASK,
+            )
+            == attrs2_1["fold_vjt_3"]
+        )
+        assert (
+            bit_field(
+                pkg_folded_neu[4],
+                Off_Cfg3_V2.Fold.Word3.FOLD_VJT_1_OFFSET,
+                Off_Cfg3_V2.Fold.Word3.FOLD_VJT_1_MASK,
+            )
+            == attrs2_2["fold_vjt_1"]
+        )
+        assert (
+            bit_field(
+                pkg_folded_neu[5],
+                Off_Cfg3_V2.Fold.Word4.FOLD_VJT_2_OFFSET,
+                Off_Cfg3_V2.Fold.Word4.FOLD_VJT_2_MASK,
+            )
+            == attrs2_2["fold_vjt_2"]
+        )
+
+    @pytest.mark.parametrize(
+        "wrapper_name,args,expected_size",
+        [
+            (
+                "gen_config_frame3_pkg_half",
+                (
+                    build_v2_dest_info_params(),
+                    build_v2_half_attrs_params(),
+                ),
+                2,
+            ),
+            (
+                "gen_config_frame3_pkg_full",
+                (
+                    build_v2_dest_info_params(),
+                    build_v2_half_attrs_params(),
+                    build_v2_full_attrs_part2_params(),
+                ),
+                4,
+            ),
+            (
+                "gen_config_frame3_pkg_folded",
+                (
+                    build_v2_folded_attrs_part1_params(),
+                    [build_v2_folded_attrs_part2_params()],
+                ),
+                4,
+            ),
+        ],
+        ids=["half", "full", "folded"],
+    )
+    def test_gen_config_frame3_pkg_wrappers(self, wrapper_name, args, expected_size):
+        result = getattr(OfflineFrameGenV2, wrapper_name)(*args)
+
+        assert result.size == expected_size
+
+    def test_gen_config_frame3_pkg_folded_wrapper_rejects_incomplete_attrs(self):
+        with pytest.raises(ValueError, match="incomplete"):
+            OfflineFrameGenV2.gen_config_frame3_pkg_folded(
+                build_v2_folded_attrs_part1_params(), []
+            )
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_sizes",
+        [
+            (
+                {
+                    "dest_info": build_v2_dest_info_params(),
+                    "full_attrs1": build_v2_half_attrs_params(),
+                    "full_attrs2": build_v2_full_attrs_part2_params(),
+                    "folded_attrs1": build_v2_folded_attrs_part1_params(),
+                    "folded_attrs2_": [
+                        build_v2_folded_attrs_part2_params(),
+                        build_v2_folded_attrs_part2_params(fold_vjt_0=10),
+                    ],
+                },
+                [2, 4, 6],
+            ),
+            (
+                {
+                    "dest_info": build_v2_dest_info_params(),
+                    "full_attrs1": None,
+                    "full_attrs2": None,
+                    "folded_attrs1": build_v2_folded_attrs_part1_params(),
+                    "folded_attrs2_": [build_v2_folded_attrs_part2_params()],
+                },
+                [0, 0, 4],
+            ),
+        ],
+        ids=["all", "folded-only"],
+    )
+    def test_gen_config_frame3_pkg_neu_valid_combinations(self, kwargs, expected_sizes):
+        result = OfflineFrameGenV2.gen_config_frame3_pkg_neu(**kwargs)
+
+        assert [pkg.size for pkg in result] == expected_sizes
+
+    @pytest.mark.parametrize(
+        "kwargs,error_match",
+        [
+            (
+                {
+                    "dest_info": build_v2_dest_info_params(),
+                    "full_attrs1": None,
+                    "full_attrs2": build_v2_full_attrs_part2_params(),
+                    "folded_attrs1": None,
+                    "folded_attrs2_": [],
+                },
+                "full neuron.*missing part1",
+            ),
+            (
+                {
+                    "dest_info": build_v2_dest_info_params(),
+                    "full_attrs1": build_v2_half_attrs_params(),
+                    "full_attrs2": None,
+                    "folded_attrs1": build_v2_folded_attrs_part1_params(),
+                    "folded_attrs2_": [],
+                },
+                "folded neuron.*missing part2",
+            ),
+            (
+                {
+                    "dest_info": build_v2_dest_info_params(),
+                    "full_attrs1": build_v2_half_attrs_params(),
+                    "full_attrs2": None,
+                    "folded_attrs1": None,
+                    "folded_attrs2_": [build_v2_folded_attrs_part2_params()],
+                },
+                "folded neuron.*missing part1",
+            ),
+        ],
+        ids=["full-missing-part1", "folded-missing-part2", "folded-missing-part1"],
+    )
+    def test_gen_config_frame3_pkg_neu_rejects_invalid_combinations(
+        self, kwargs, error_match
+    ):
+        with pytest.raises(ValueError, match=error_match):
+            OfflineFrameGenV2.gen_config_frame3_pkg_neu(**kwargs)
+
+    @pytest.mark.parametrize(
+        "weight_width, input_width, csc_compress",
+        [
+            (8, 8, False),
+            (DataWidth.WIDTH_4BIT, DataWidth.WIDTH_2BIT, False),
+            (DataWidth.WIDTH_8BIT, DataWidth.WIDTH_1BIT, CSCAccelerateMode.ENABLE),
+        ],
+    )
+    def test_gen_config_frame3_weight_pkg(
+        self,
+        weight_width: DataWidthLE8Like,
+        input_width: DataWidthLE8Like,
+        csc_compress: bool | CSCAccelerateMode,
+        fixed_rng: np.random.Generator,
+    ):
+        is_sparse = (
+            csc_compress != CSCAccelerateMode.DISABLE and csc_compress is not False
+        )
+        width_bits = normalize_width_bits(weight_width)
+        weight = build_v2_weight_array(
+            32, width_bits, True, fixed_rng, sparse_ratio=0.4 if is_sparse else 0.0
+        )
 
         result = OfflineFrameGenV2.gen_config_frame3_weight_pkg(
-            weight, 8, csc_compress=False
+            weight, weight_width, input_width, csc_compress
         )
-        assert result.shape == (4,)
+
+        if is_sparse:
+            input_bits = normalize_width_bits(input_width)
+            expected = weight_csc_pack(weight, width_bits, input_bits)
+        else:
+            expected = weight_dense_pack(weight, width_bits)
+
+        assert np.array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "weight_width, input_width",
+        [
+            (DataWidth.WIDTH_16BIT, DataWidth.WIDTH_1BIT),
+            (DataWidth.WIDTH_1BIT, DataWidth.WIDTH_32BIT),
+        ],
+    )
+    def test_gen_config_frame3_weight_pkg_rejects_unsupported_widths(
+        self, weight_width, input_width
+    ):
+        with pytest.raises(ValueError, match="1/2/4/8-bit"):
+            OfflineFrameGenV2.gen_config_frame3_weight_pkg(
+                np.ones(8, dtype=np.int8), weight_width, input_width
+            )
 
     @pytest.mark.parametrize(
         "ts, axon, data, target_lcn",
@@ -330,36 +646,101 @@ class TestOfflineFrameGenV2:
                 np.array([0b0011_0100, 0b0011_0100]),
                 np.array([0b0_0100_1011_0011, 0b100_1011_0011]),
                 np.array([-16, 1], dtype=np.int8),
-                LCN_EX.LCN_4X,  # 5, 12
+                LCN_EX.LCN_4X,
             ),
             (
                 0b1011_0100,
                 0b1_1011_0011,
                 np.array([10], dtype=np.uint8),
-                LCN_EX.LCN_1X,  # 8, 9
+                LCN_EX.LCN_1X,
             ),
         ],
     )
-    def test_wf1(self, ts, axon, data, target_lcn):
-        pkt_offset = CoordZXYOffset(1, 1, 1)
-        pkt_ncopy = AERPacketZXYCopy(0, 1, 1)
+    def test_wf1(self, v2_packet_route, ts, axon, data, target_lcn):
+        pkt_offset, pkt_ncopy = v2_packet_route
         wf1 = OfflineFrameGenV2.gen_work_frame1(
             pkt_offset, pkt_ncopy, ts, axon, target_lcn, data
         )
-        print_frame(wf1, version=2, target_lcn=target_lcn)
 
-        TS_WIDTH, AX_WIDTH = OfflineFrameGenV2.LCN_TO_TS_AXON_WIDTHS[target_lcn]
-        if isinstance(ts, np.ndarray):
-            ts = ts[0]
-        if isinstance(axon, np.ndarray):
-            axon = axon[0]
+        ts0 = ts[0] if isinstance(ts, np.ndarray) else ts
+        axon0 = axon[0] if isinstance(axon, np.ndarray) else axon
+        ts_width, ax_width = OfflineFrameGenV2.LCN_TO_TS_AXON_WIDTHS[target_lcn.value]
 
+        assert wf1.dtype == FRAME_DTYPE
+        assert bit_field(
+            wf1[0],
+            Off_Work1_V2.TIMESTEP_HIGH7_OFFSET,
+            Off_Work1_V2.TIMESTEP_HIGH7_MASK,
+        ) == ((ts0 >> (ts_width - 1)) & Off_Work1_V2.TIMESTEP_HIGH7_MASK)
         assert (
-            wf1[0] >> Off_Work1_V2.TIMESTEP_HIGH7_OFFSET
-        ) & Off_Work1_V2.TIMESTEP_HIGH7_MASK == (
-            ts >> (TS_WIDTH - 1)
-        ) & Off_Work1_V2.TIMESTEP_HIGH7_MASK
-        assert (wf1[0] >> Off_Work1_V2.AXON_ADDR_OFFSET) & _mask(AX_WIDTH) == axon
+            bit_field(wf1[0], Off_Work1_V2.AXON_ADDR_OFFSET, _mask(ax_width)) == axon0
+        )
+
+    def test_wf1_filters_zero_payloads(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        wf1 = OfflineFrameGenV2.gen_work_frame1(
+            pkt_offset,
+            pkt_ncopy,
+            np.array([1, 2, 3, 4]),
+            np.array([10, 11, 12, 13]),
+            LCN_EX.LCN_1X,
+            np.array([0, 5, 0, 6], dtype=np.uint8),
+        )
+
+        assert wf1.shape == (2,)
+        assert bit_field(wf1[0], Off_Work1_V2.DATA_OFFSET, Off_Work1_V2.DATA_MASK) == 5
+        assert bit_field(wf1[1], Off_Work1_V2.DATA_OFFSET, Off_Work1_V2.DATA_MASK) == 6
+
+    @pytest.mark.parametrize(
+        "timesteps, axons, data",
+        [
+            ([1, 2], [3], [4, 5]),
+            ([1, 2], [3, 4], [5]),
+        ],
+    )
+    def test_wf1_rejects_mismatched_lengths(
+        self, v2_packet_route, timesteps, axons, data
+    ):
+        pkt_offset, pkt_ncopy = v2_packet_route
+
+        with pytest.raises(ValueError, match="size"):
+            OfflineFrameGenV2.gen_work_frame1(
+                pkt_offset, pkt_ncopy, timesteps, axons, LCN_EX.LCN_1X, data
+            )
+
+    def test_control_frames(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        ctrl1 = OfflineFrameGenV2.gen_control_frame1(pkt_offset, pkt_ncopy, 123)
+        ctrl2 = OfflineFrameGenV2.gen_control_frame2(pkt_offset, pkt_ncopy)
+        complete = OfflineFrameGenV2.gen_complete_frame(pkt_offset, pkt_ncopy, 7)
+
+        assert single_frame_header_check(ctrl1[0], FH.CTRL_TYPE1)
+        assert single_frame_header_check(ctrl2[0], FH.CTRL_TYPE2)
+        assert single_frame_header_check(complete[0], FH.CTRL_TYPE3)
+        assert (
+            bit_field(ctrl1[0], FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK)
+            == 123
+        )
+        assert (
+            bit_field(
+                complete[0], FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK
+            )
+            == 7
+        )
+
+    def test_control_frame1_rejects_overflow(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        with pytest.raises(ValueError, match="overflow"):
+            OfflineFrameGenV2.gen_control_frame1(
+                pkt_offset, pkt_ncopy, Off_Ctrl1_V2.NUM_TIMESTEP_MASK + 1
+            )
+
+    def test_complete_frame_rejects_overflow(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        with pytest.raises(ValueError, match="thread_id"):
+            OfflineFrameGenV2.gen_complete_frame(
+                pkt_offset, pkt_ncopy, Off_Ctrl3_V2.THREAD_ID_MASK + 1
+            )
 
 
 @pytest.mark.parametrize(
@@ -377,27 +758,19 @@ class TestOfflineFrameGenV2:
     ],
 )
 def test_weight_uncompressed_unpack(size, weight_width, signed, fixed_rng):
-    if signed:
-        _dtype = np.int8
-        _max = _mask(weight_width - 1)
-        _min = -(_max + 1)
-    else:
-        _dtype = np.uint8
-        _min, _max = 0, _mask(weight_width)
-
-    weight = fixed_rng.integers(_min, _max, size=size, dtype=_dtype)
+    weight = build_v2_weight_array(size, weight_width, signed, fixed_rng)
     mapped = weight_dense_pack(weight, weight_width)
-    assert mapped.dtype == FRAME_DTYPE
 
     align_size = 128 // weight_width
     expected_size = math.ceil(weight.size / align_size) * (
         128 // (FRAME_DTYPE(0).nbytes * 8)
     )
+
+    assert mapped.dtype == FRAME_DTYPE
     assert mapped.shape == (expected_size,)
 
     unmapped = weight_dense_unpack(mapped, weight_width, signed, size)
-    assert unmapped.dtype == _dtype
-    assert unmapped.size == weight.size
+    assert unmapped.dtype == weight.dtype
     assert np.array_equal(weight, unmapped)
 
 
@@ -416,35 +789,25 @@ def test_weight_uncompressed_unpack(size, weight_width, signed, fixed_rng):
     ],
 )
 def test_weight_csc_unpack(size, weight_width, signed, fixed_rng):
-    if signed:
-        _dtype = np.int8
-        _max = _mask(weight_width - 1)
-        _min = -(_max + 1)
-    else:
-        _dtype = np.uint8
-        _min, _max = 0, _mask(weight_width)
+    weight = build_v2_weight_array(
+        size, weight_width, signed, fixed_rng, sparse_ratio=0.4
+    )
+    mapped = weight_csc_pack(weight, weight_width, input_width=1)
 
-    weight = fixed_rng.integers(_min, _max, size=size, dtype=_dtype)
-    # Sparse
-    sparse_ratio = 0.4
-    num_zeros = int(weight.size * sparse_ratio)
-    if num_zeros > 0:
-        flat_indices = fixed_rng.choice(weight.size, size=num_zeros, replace=False)
-        weight.flat[flat_indices] = 0
+    n_nonzero_per_addr = {1: 7, 2: 7, 4: 6, 8: 5}[weight_width]
+    expected_size = math.ceil(np.count_nonzero(weight) / n_nonzero_per_addr) * 2
 
-    mapped = weight_csc_pack(weight, weight_width)
     assert mapped.dtype == FRAME_DTYPE
-
-    N_NONZERO_WEIGHT_PER_ADDR = {1: 7, 2: 7, 4: 6, 8: 5}
-    align_size = N_NONZERO_WEIGHT_PER_ADDR[weight_width]
-    # Only store non-zero weights
-    expected_size = math.ceil(np.count_nonzero(weight) / align_size) * 2
     assert mapped.shape == (expected_size,)
 
     unmapped = weight_csc_unpack(mapped, weight_width, signed, size)
-    assert unmapped.dtype == _dtype
-    assert unmapped.size == weight.size
+    assert unmapped.dtype == weight.dtype
     assert np.array_equal(weight, unmapped)
+
+
+def test_weight_csc_unpack_rejects_odd_frame_count():
+    with pytest.raises(ValueError, match="even"):
+        weight_csc_unpack(np.array([1], dtype=FRAME_DTYPE), 8, True, 1)
 
 
 @pytest.mark.parametrize(
@@ -459,7 +822,7 @@ def test_weight_csc_unpack(size, weight_width, signed, fixed_rng):
 def test_weightcsc_unpack_check_aligned(size, sparse, expectation):
     weight = np.ones(size, dtype=np.int8)
     if sparse:
-        weight[5] = 0  # As long as there is a zero, we can pad
+        weight[5] = 0
 
     with expectation:
-        _ = weight_csc_pack(weight, 8)
+        weight_csc_pack(weight, 8, 8)

--- a/tests/test_core_model_v2.py
+++ b/tests/test_core_model_v2.py
@@ -14,83 +14,50 @@ from paicorelib.core_defs_v2 import (
 )
 from paicorelib.core_model_v2 import OfflineCoreRegV2
 
+from .utils import build_v2_core_reg_params
+
 
 class TestCoreRegModel:
-    @pytest.fixture
-    def default_params(self):
-        return {
-            "snn_ann": SNNMode.SNN,
-            "max_pooling": PoolingMode.AVERAGE,
-            "add_potential": AddPotentialMode.NORMAL,
-            "zero_output": ZeroOutputMode.DISABLE,
-            "input_sign": DataSign.UNSIGNED,
-            "input_width": DataWidth.WIDTH_1BIT,
-            "output_sign": DataSign.UNSIGNED,
-            "output_width": DataWidth.WIDTH_1BIT,
-            "weight_sign": DataSign.UNSIGNED,
-            "weight_width": DataWidth.WIDTH_1BIT,
-            "lcn": LCN_EX.LCN_1X,
-            "target_lcn": LCN_EX.LCN_1X,
-            "axon_skew": 0,
-            "neuron_number": 100,
-            "test_core_xy": 0,
-            "test_core_x": 0,
-            "test_core_y": 0,
-            "global_send": 0,
-            "csc_accelerate": CSCAccelerateMode.DISABLE,
-            "global_receive": 0,
-            "thread_number": 1,
-            "busy_cycle": 10,
-            "delay_cycle": 2,
-            "width_cycle": 2,
-            "tick_start": 0,
-            "tick_duration": 100,
-            "tick_initial": 0,
-        }
-
     @pytest.mark.parametrize(
-        "params_update",
+        "params",
         [
-            {},  # Default legal params
-            {
-                "snn_ann": SNNMode.ANN,
-                "max_pooling": PoolingMode.MAX,
-                "add_potential": AddPotentialMode.DIRECT_ADD,
-                "zero_output": ZeroOutputMode.ENABLE,
-                "input_sign": DataSign.SIGNED,
-                "input_width": DataWidth.WIDTH_8BIT,
-                "output_sign": DataSign.SIGNED,
-                "output_width": DataWidth.WIDTH_8BIT,
-                "weight_sign": DataSign.SIGNED,
-                "weight_width": DataWidth.WIDTH_8BIT,
-                "lcn": LCN_EX.LCN_4X,
-                "target_lcn": LCN_EX.LCN_4X,
-                "axon_skew": OfflineCoreRegLimV2.AXON_SKEW_MAX,
-                "neuron_number": OfflineCoreRegLimV2.NEURON_NUMBER_MAX,
-                "test_core_xy": OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
-                "test_core_x": OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
-                "test_core_y": OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
-                "global_send": OfflineCoreRegLimV2.GLOBAL_SEND_MAX,
-                "csc_accelerate": CSCAccelerateMode.ENABLE,
-                "global_receive": OfflineCoreRegLimV2.GLOBAL_RECEIVE_MAX,
-                "thread_number": OfflineCoreRegLimV2.THREAD_NUMBER_MAX,
-                "busy_cycle": OfflineCoreRegLimV2.BUSY_CYCLE_MAX,
-                "delay_cycle": OfflineCoreRegLimV2.DELAY_CYCLE_MAX,
-                "width_cycle": OfflineCoreRegLimV2.WIDTH_CYCLE_MAX,
-                "tick_start": OfflineCoreRegLimV2.TICK_START_MAX,
-                "tick_duration": OfflineCoreRegLimV2.TICK_DURATION_MAX,
-                "tick_initial": OfflineCoreRegLimV2.TICK_INITIAL_MAX,
-            },
+            build_v2_core_reg_params(),
+            build_v2_core_reg_params(
+                snn_ann=SNNMode.ANN,
+                max_pooling=PoolingMode.MAX,
+                add_potential=AddPotentialMode.DIRECT_ADD,
+                zero_output=ZeroOutputMode.ENABLE,
+                input_sign=DataSign.SIGNED,
+                input_width=DataWidth.WIDTH_8BIT,
+                output_sign=DataSign.SIGNED,
+                output_width=DataWidth.WIDTH_8BIT,
+                weight_sign=DataSign.SIGNED,
+                weight_width=DataWidth.WIDTH_8BIT,
+                lcn=LCN_EX.LCN_4X,
+                target_lcn=LCN_EX.LCN_4X,
+                axon_skew=OfflineCoreRegLimV2.AXON_SKEW_MAX,
+                neuron_number=OfflineCoreRegLimV2.NEURON_NUMBER_MAX,
+                test_core_xy=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+                test_core_x=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+                test_core_y=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+                global_send=OfflineCoreRegLimV2.GLOBAL_SEND_MAX,
+                csc_accelerate=CSCAccelerateMode.ENABLE,
+                global_receive=OfflineCoreRegLimV2.GLOBAL_RECEIVE_MAX,
+                thread_number=OfflineCoreRegLimV2.THREAD_NUMBER_MAX,
+                busy_cycle=OfflineCoreRegLimV2.BUSY_CYCLE_MAX,
+                delay_cycle=OfflineCoreRegLimV2.DELAY_CYCLE_MAX,
+                width_cycle=OfflineCoreRegLimV2.WIDTH_CYCLE_MAX,
+                tick_start=OfflineCoreRegLimV2.TICK_START_MAX,
+                tick_duration=OfflineCoreRegLimV2.TICK_DURATION_MAX,
+                tick_initial=OfflineCoreRegLimV2.TICK_INITIAL_MAX,
+            ),
         ],
     )
-    def test_legal(self, ensure_dump_dir, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_legal(self, ensure_dump_dir, params):
         core_reg = OfflineCoreRegV2.model_validate(params, strict=True)
-        core_reg_dict = core_reg.model_dump_json(indent=2)
 
         with open(ensure_dump_dir / "core_reg.json", "w") as f:
-            f.write(core_reg_dict)
+            f.write(core_reg.model_dump_json(indent=2))
 
     @pytest.mark.parametrize(
         "params_update",
@@ -111,8 +78,35 @@ class TestCoreRegModel:
             {"tick_initial": OfflineCoreRegLimV2.TICK_INITIAL_MAX + 1},
         ],
     )
-    def test_illegal(self, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_illegal(self, params_update):
         with pytest.raises(ValidationError):
-            OfflineCoreRegV2.model_validate(params, strict=True)
+            OfflineCoreRegV2.model_validate(
+                build_v2_core_reg_params(**params_update), strict=True
+            )
+
+    @pytest.mark.parametrize(
+        "params_update",
+        [
+            {
+                "max_pooling": PoolingMode.MAX,
+                "weight_width": DataWidth.WIDTH_8BIT,
+            },
+            {
+                "add_potential": AddPotentialMode.DIRECT_ADD,
+                "weight_width": DataWidth.WIDTH_4BIT,
+            },
+        ],
+    )
+    def test_force_weight_width_to_1bit(self, params_update):
+        core_reg = OfflineCoreRegV2.model_validate(
+            build_v2_core_reg_params(**params_update), strict=True
+        )
+
+        assert core_reg.weight_width == DataWidth.WIDTH_1BIT
+
+    def test_keep_weight_width_when_not_forced(self):
+        core_reg = OfflineCoreRegV2.model_validate(
+            build_v2_core_reg_params(weight_width=DataWidth.WIDTH_8BIT), strict=True
+        )
+
+        assert core_reg.weight_width == DataWidth.WIDTH_8BIT

--- a/tests/test_neuron_model_v2.py
+++ b/tests/test_neuron_model_v2.py
@@ -1,67 +1,54 @@
 import pytest
 from pydantic import ValidationError
 
-from paicorelib.neuron_defs import ResetMode
 from paicorelib.neuron_defs_v2 import (
     FoldType,
-    LateralInhibitionMode,
-    LeakAddMode,
-    LeakMultiComparisonOrder,
-    LeakMultiInputMode,
-    LeakMultiMode,
     NeuronType,
     OfflineNeuRegLimV2,
     OutputType,
-    ThresholdNegMode,
-    ThresholdPosMode,
-    WeightCompressType,
 )
 from paicorelib.neuron_model_v2 import (
     OfflineNeuDestInfoV2,
     OfflineNeuFoldedAttrsV2Part1,
+    OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2,
+    OfflineNeuFullConfV2,
     OfflineNeuHalfAttrsV2,
+    OfflineNeuHalfConfV2,
+    OnlineNeuFoldedAttrsV2Part1,
+    OnlineNeuFoldedAttrsV2Part2,
+)
+from tests.utils import (
+    build_v2_dest_info_params,
+    build_v2_folded_attrs_part1_params,
+    build_v2_folded_attrs_part2_params,
+    build_v2_full_attrs_part2_params,
+    build_v2_half_attrs_params,
 )
 
 
 class TestOfflineNeuDestInfoV2Model:
-    @pytest.fixture
-    def default_params(self):
-        return {
-            "tick_relative": 1,
-            "addr_axon": 1,
-            "addr_core_xy": 0,
-            "addr_core_x": 0,
-            "addr_core_y": 0,
-            "addr_copy_xy": 0,
-            "addr_copy_x": 0,
-            "addr_copy_y": 0,
-        }
-
     @pytest.mark.parametrize(
-        "params_update",
+        "params",
         [
-            {},
-            {
-                "tick_relative": 0,
-                "addr_axon": 99,
-                "addr_core_xy": OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
-                "addr_core_x": OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
-                "addr_core_y": OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
-                "addr_copy_xy": OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
-                "addr_copy_x": OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
-                "addr_copy_y": OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
-            },
+            build_v2_dest_info_params(),
+            build_v2_dest_info_params(
+                tick_relative=0,
+                addr_axon=99,
+                addr_core_xy=OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
+                addr_core_x=OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
+                addr_core_y=OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
+                addr_copy_xy=OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
+                addr_copy_x=OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
+                addr_copy_y=OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX,
+            ),
         ],
     )
-    def test_legal(self, ensure_dump_dir, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_legal(self, ensure_dump_dir, params):
         neuron = OfflineNeuDestInfoV2.model_validate(params, strict=True)
-        neuron_dict = neuron.model_dump_json(indent=2)
 
         with open(ensure_dump_dir / "neuron_destination2_5.json", "w") as f:
-            f.write(neuron_dict)
+            f.write(neuron.model_dump_json(indent=2))
 
     @pytest.mark.parametrize(
         "params_update",
@@ -72,49 +59,34 @@ class TestOfflineNeuDestInfoV2Model:
             {"addr_core_xy": OfflineNeuRegLimV2.ADDR_CORE_COORD_MAX + 1},
         ],
     )
-    def test_illegal(self, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_illegal(self, params_update):
         with pytest.raises(ValidationError):
-            OfflineNeuDestInfoV2.model_validate(params, strict=True)
+            OfflineNeuDestInfoV2.model_validate(
+                build_v2_dest_info_params(**params_update), strict=True
+            )
 
 
 class TestOfflineNeuHalfAttrsV2Model:
-    @pytest.fixture
-    def default_params(self):
-        return {
-            "weight_skew": 0,
-            "weight_address_start": 0,
-            "weight_address_end": 0,
-            "output_type": OutputType.VALUE,
-            "fold_type": FoldType.UNFOLDED,
-            "neuron_type": NeuronType.HALF,
-            "vjt": 0,
-        }
-
     @pytest.mark.parametrize(
-        "params_update",
+        "params",
         [
-            {},
-            {
-                "weight_skew": OfflineNeuRegLimV2.WEIGHT_SKEW_MAX,
-                "weight_address_start": OfflineNeuRegLimV2.WEIGHT_ADDRESS_MAX,
-                "weight_address_end": OfflineNeuRegLimV2.WEIGHT_ADDRESS_MAX,
-                "output_type": OutputType.POTENTIAL,
-                "fold_type": FoldType.FOLDED,
-                "neuron_type": NeuronType.FULL,
-                "vjt": 100,
-            },
+            build_v2_half_attrs_params(),
+            build_v2_half_attrs_params(
+                weight_skew=OfflineNeuRegLimV2.WEIGHT_SKEW_MAX,
+                weight_address_start=OfflineNeuRegLimV2.WEIGHT_ADDRESS_MAX,
+                weight_address_end=OfflineNeuRegLimV2.WEIGHT_ADDRESS_MAX,
+                output_type=OutputType.POTENTIAL,
+                fold_type=FoldType.FOLDED,
+                neuron_type=NeuronType.FULL,
+                vjt=100,
+            ),
         ],
     )
-    def test_legal(self, ensure_dump_dir, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_legal(self, ensure_dump_dir, params):
         neuron = OfflineNeuHalfAttrsV2.model_validate(params, strict=True)
-        neuron_dict = neuron.model_dump_json(indent=2)
 
         with open(ensure_dump_dir / "neuron_half_attrs.json", "w") as f:
-            f.write(neuron_dict)
+            f.write(neuron.model_dump_json(indent=2))
 
     @pytest.mark.parametrize(
         "params_update",
@@ -123,79 +95,46 @@ class TestOfflineNeuHalfAttrsV2Model:
             {"weight_address_start": OfflineNeuRegLimV2.WEIGHT_ADDRESS_MAX + 1},
         ],
     )
-    def test_illegal(self, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_illegal(self, params_update):
         with pytest.raises(ValidationError):
-            OfflineNeuHalfAttrsV2.model_validate(params, strict=True)
+            OfflineNeuHalfAttrsV2.model_validate(
+                build_v2_half_attrs_params(**params_update), strict=True
+            )
 
 
 class TestOfflineNeuFullAttrsV2Model:
-    @pytest.fixture
-    def default_params(self):
-        return {
-            "weight_skew": 0,
-            "weight_address_start": 0,
-            "weight_address_end": 1000,
-            "output_type": OutputType.VALUE,
-            "fold_type": FoldType.UNFOLDED,
-            "neuron_type": NeuronType.FULL,
-            "vjt": 0,
-            "reset_mode": ResetMode.MODE_NORMAL,
-            "reset_v": 0,
-            "threshold_neg_mode": ThresholdNegMode.FIRE,
-            "threshold_pos_mode": ThresholdPosMode.FIRE,
-            "threshold_neg": 0,
-            "threshold_pos": 0,
-            "lateral_inhibition": LateralInhibitionMode.DISABLE,
-            "leak_multi_sequence": LeakMultiComparisonOrder.BEFORE_COMPARE,
-            "leak_multi_input": LeakMultiInputMode.DISABLE,
-            "leak_multi_mode": LeakMultiMode.DISABLE,
-            "leak_add_mode": LeakAddMode.FORWARD,
-            "leak_tau": 0,
-            "leak_v": 0,
-            "weight_compress": WeightCompressType.DENSE,
-            "vjt_initial": 0,
-        }
-
     @pytest.mark.parametrize(
-        "params_update",
+        "common_update, part2_update",
         [
-            {},
-            {
-                "weight_skew": 1,
-                "weight_address_start": 0,
-                "weight_address_end": 1,
-                "output_type": OutputType.POTENTIAL,
-                "fold_type": FoldType.FOLDED,
-                "neuron_type": NeuronType.FULL,
-                "vjt": 0,
-                "reset_mode": ResetMode.MODE_LINEAR,
-                "reset_v": OfflineNeuRegLimV2.RESET_V_MAX,
-                "threshold_neg_mode": ThresholdNegMode.FLOOR,
-                "threshold_pos_mode": ThresholdPosMode.CEILING,
-                "threshold_neg": -100,
-                "threshold_pos": 100,
-                "lateral_inhibition": LateralInhibitionMode.ENABLE,
-                "leak_multi_sequence": LeakMultiComparisonOrder.AFTER_COMPARE,
-                "leak_multi_input": LeakMultiInputMode.ENABLE,
-                "leak_multi_mode": LeakMultiMode.ENABLE,
-                "leak_add_mode": LeakAddMode.BACKWARD,
-                "leak_tau": OfflineNeuRegLimV2.LEAK_TAU_MAX,
-                "leak_v": OfflineNeuRegLimV2.LEAK_V_MAX,
-                "weight_compress": WeightCompressType.SPARSE,
-                "vjt_initial": OfflineNeuRegLimV2.VJT_INITIAL_MAX,
-            },
+            ({}, {}),
+            (
+                {
+                    "weight_skew": 1,
+                    "weight_address_end": 1,
+                    "output_type": OutputType.POTENTIAL,
+                    "fold_type": FoldType.FOLDED,
+                    "neuron_type": NeuronType.FULL,
+                },
+                {
+                    "reset_v": OfflineNeuRegLimV2.RESET_V_MAX,
+                    "threshold_neg": -100,
+                    "threshold_pos": 100,
+                    "leak_tau": OfflineNeuRegLimV2.LEAK_TAU_MAX,
+                    "leak_v": OfflineNeuRegLimV2.LEAK_V_MAX,
+                    "vjt_initial": OfflineNeuRegLimV2.VJT_INITIAL_MAX,
+                },
+            ),
         ],
     )
-    def test_legal(self, ensure_dump_dir, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_legal(self, ensure_dump_dir, common_update, part2_update):
+        params = build_v2_half_attrs_params(
+            **({"neuron_type": NeuronType.FULL} | common_update)
+        )
+        params.update(build_v2_full_attrs_part2_params(**part2_update))
         neuron = OfflineNeuFullAttrsV2.model_validate(params, strict=True)
-        neuron_dict = neuron.model_dump_json(indent=2)
 
         with open(ensure_dump_dir / "neuron_common.json", "w") as f:
-            f.write(neuron_dict)
+            f.write(neuron.model_dump_json(indent=2))
 
     @pytest.mark.parametrize(
         "params_update",
@@ -210,49 +149,32 @@ class TestOfflineNeuFullAttrsV2Model:
             {"vjt_initial": OfflineNeuRegLimV2.VJT_INITIAL_MAX + 1},
         ],
     )
-    def test_illegal(self, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_illegal(self, params_update):
+        params = build_v2_half_attrs_params(neuron_type=NeuronType.FULL)
+        params.update(build_v2_full_attrs_part2_params(**params_update))
+
         with pytest.raises(ValidationError):
             OfflineNeuFullAttrsV2.model_validate(params, strict=True)
 
 
 class TestOfflineNeuFoldedAttrsV2Part1Model:
-    @pytest.fixture
-    def default_params(self):
-        return {
-            "fold_range_xy": 1,
-            "fold_range_x": 1,
-            "fold_range_y": 1,
-            "fold_skew_xy": 0,
-            "fold_skew_x": 0,
-            "fold_skew_y": 0,
-            "fold_axon_xy": 0,
-            "fold_axon_x": 0,
-            "fold_axon_y": 0,
-            "fold_number": 1,
-        }
-
     @pytest.mark.parametrize(
-        "params_update",
+        "params",
         [
-            {},
-            {
-                "fold_range_xy": 2,
-                "fold_range_x": 2,
-                "fold_range_y": 2,
-                "fold_number": 8,
-            },
+            build_v2_folded_attrs_part1_params(),
+            build_v2_folded_attrs_part1_params(
+                fold_range_xy=2,
+                fold_range_x=2,
+                fold_range_y=2,
+                fold_number=8,
+            ),
         ],
     )
-    def test_legal(self, ensure_dump_dir, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_legal(self, ensure_dump_dir, params):
         neuron = OfflineNeuFoldedAttrsV2Part1.model_validate(params, strict=True)
-        neuron_dict = neuron.model_dump_json(indent=2)
 
         with open(ensure_dump_dir / "folded_neuron_attrs.json", "w") as f:
-            f.write(neuron_dict)
+            f.write(neuron.model_dump_json(indent=2))
 
     @pytest.mark.parametrize(
         "params_update",
@@ -261,12 +183,67 @@ class TestOfflineNeuFoldedAttrsV2Part1Model:
             {"fold_skew_xy": OfflineNeuRegLimV2.FOLD_SKEW_MAX + 1},
             {"fold_axon_xy": OfflineNeuRegLimV2.FOLD_AXON_MAX + 1},
             {"fold_number": OfflineNeuRegLimV2.FOLD_NUMBER_MAX + 1},
-            # Logic error: fold_number != range_xy * range_x * range_y
             {"fold_range_xy": 2, "fold_number": 1},
         ],
     )
-    def test_illegal(self, default_params, params_update):
-        params = default_params.copy()
-        params.update(params_update)
+    def test_illegal(self, params_update):
         with pytest.raises((ValidationError, ValueError)):
-            OfflineNeuFoldedAttrsV2Part1.model_validate(params, strict=True)
+            OfflineNeuFoldedAttrsV2Part1.model_validate(
+                build_v2_folded_attrs_part1_params(**params_update), strict=True
+            )
+
+
+class TestAdditionalV2Models:
+    def test_offline_folded_attrs_part2(self):
+        folded_attrs = OfflineNeuFoldedAttrsV2Part2.model_validate(
+            build_v2_folded_attrs_part2_params(
+                fold_vjt_3=300,
+                fold_vjt_2=200,
+                fold_vjt_1=100,
+                fold_vjt_0=0,
+            ),
+            strict=True,
+        )
+
+        assert folded_attrs.fold_vjt_3 == 300
+        assert folded_attrs.fold_vjt_0 == 0
+
+    def test_online_folded_attrs_models_accept_float_values(self):
+        attrs1 = OnlineNeuFoldedAttrsV2Part1.model_validate(
+            build_v2_folded_attrs_part1_params(), strict=True
+        )
+        attrs2 = OnlineNeuFoldedAttrsV2Part2.model_validate(
+            {
+                "fold_vjt_3": 3.5,
+                "fold_vjt_2": 2.5,
+                "fold_vjt_1": 1.5,
+                "fold_vjt_0": 0.5,
+            },
+            strict=True,
+        )
+
+        assert attrs1.fold_number == 1
+        assert attrs2.fold_vjt_3 == 3.5
+
+    def test_offline_conf_wrappers_validate_nested_models(self):
+        half_conf = OfflineNeuHalfConfV2.model_validate(
+            {
+                "attrs": build_v2_half_attrs_params(),
+                "dest_info": build_v2_dest_info_params(),
+            },
+            strict=True,
+        )
+        full_conf = OfflineNeuFullConfV2.model_validate(
+            {
+                "attrs": {
+                    **build_v2_half_attrs_params(neuron_type=NeuronType.FULL),
+                    **build_v2_full_attrs_part2_params(),
+                },
+                "dest_info": build_v2_dest_info_params(),
+            },
+            strict=True,
+        )
+
+        assert isinstance(half_conf.attrs, OfflineNeuHalfAttrsV2)
+        assert isinstance(half_conf.dest_info, OfflineNeuDestInfoV2)
+        assert isinstance(full_conf.attrs, OfflineNeuFullAttrsV2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,34 @@ import numpy as np
 import pytest
 from numpy.typing import DTypeLike
 
+from paicorelib.coordinate import CoordZXYOffset
+from paicorelib.core_defs import LCN_EX
+from paicorelib.core_defs_v2 import (
+    AddPotentialMode,
+    CSCAccelerateMode,
+    DataSign,
+    DataWidth,
+    PoolingMode,
+    SNNMode,
+    ZeroOutputMode,
+)
+from paicorelib.neuron_defs import ResetMode
+from paicorelib.neuron_defs_v2 import (
+    FoldType,
+    LateralInhibitionMode,
+    LeakAddMode,
+    LeakMultiComparisonOrder,
+    LeakMultiInputMode,
+    LeakMultiMode,
+    NeuronType,
+    OutputType,
+    ThresholdNegMode,
+    ThresholdPosMode,
+    WeightCompressType,
+)
+from paicorelib.routing_hexa import AERPacketZXYCopy
+from paicorelib.utils import _mask
+
 __all__ = ["ParamTestCase", "make_test", "TestCase"]
 
 
@@ -104,3 +132,151 @@ def make_dump_dir(
             f.unlink(missing_ok=True)
 
     return p
+
+
+def with_overrides(base: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    params = base.copy()
+    params.update(overrides)
+    return params
+
+
+def build_v2_core_reg_params(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "snn_ann": SNNMode.SNN,
+        "max_pooling": PoolingMode.AVERAGE,
+        "add_potential": AddPotentialMode.NORMAL,
+        "zero_output": ZeroOutputMode.DISABLE,
+        "input_sign": DataSign.UNSIGNED,
+        "input_width": DataWidth.WIDTH_1BIT,
+        "output_sign": DataSign.UNSIGNED,
+        "output_width": DataWidth.WIDTH_1BIT,
+        "weight_sign": DataSign.UNSIGNED,
+        "weight_width": DataWidth.WIDTH_1BIT,
+        "lcn": LCN_EX.LCN_1X,
+        "target_lcn": LCN_EX.LCN_1X,
+        "axon_skew": 0,
+        "neuron_number": 100,
+        "test_core_xy": 0,
+        "test_core_x": 0,
+        "test_core_y": 0,
+        "global_send": 0,
+        "csc_accelerate": CSCAccelerateMode.DISABLE,
+        "global_receive": 0,
+        "thread_number": 1,
+        "busy_cycle": 10,
+        "delay_cycle": 2,
+        "width_cycle": 2,
+        "tick_start": 0,
+        "tick_duration": 100,
+        "tick_initial": 0,
+    }
+    return with_overrides(base, **overrides)
+
+
+def build_v2_dest_info_params(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "tick_relative": 1,
+        "addr_axon": 1,
+        "addr_core_xy": 0,
+        "addr_core_x": 0,
+        "addr_core_y": 0,
+        "addr_copy_xy": 0,
+        "addr_copy_x": 0,
+        "addr_copy_y": 0,
+    }
+    return with_overrides(base, **overrides)
+
+
+def build_v2_half_attrs_params(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "weight_skew": 0,
+        "weight_address_start": 0,
+        "weight_address_end": 0,
+        "output_type": OutputType.VALUE,
+        "fold_type": FoldType.UNFOLDED,
+        "neuron_type": NeuronType.HALF,
+        "vjt": 0,
+    }
+    return with_overrides(base, **overrides)
+
+
+def build_v2_full_attrs_part2_params(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "reset_mode": ResetMode.MODE_NORMAL,
+        "reset_v": 0,
+        "threshold_neg_mode": ThresholdNegMode.FIRE,
+        "threshold_pos_mode": ThresholdPosMode.FIRE,
+        "threshold_neg": 0,
+        "threshold_pos": 0,
+        "lateral_inhibition": LateralInhibitionMode.DISABLE,
+        "leak_multi_sequence": LeakMultiComparisonOrder.BEFORE_COMPARE,
+        "leak_multi_input": LeakMultiInputMode.DISABLE,
+        "leak_multi_mode": LeakMultiMode.DISABLE,
+        "leak_add_mode": LeakAddMode.FORWARD,
+        "leak_tau": 0,
+        "leak_v": 0,
+        "weight_compress": WeightCompressType.DENSE,
+        "vjt_initial": 0,
+    }
+    return with_overrides(base, **overrides)
+
+
+def build_v2_folded_attrs_part1_params(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "fold_range_xy": 1,
+        "fold_range_x": 1,
+        "fold_range_y": 1,
+        "fold_skew_xy": 0,
+        "fold_skew_x": 0,
+        "fold_skew_y": 0,
+        "fold_axon_xy": 0,
+        "fold_axon_x": 0,
+        "fold_axon_y": 0,
+        "fold_number": 1,
+    }
+    return with_overrides(base, **overrides)
+
+
+def build_v2_folded_attrs_part2_params(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "fold_vjt_3": 0,
+        "fold_vjt_2": 1,
+        "fold_vjt_1": 2,
+        "fold_vjt_0": 3,
+    }
+    return with_overrides(base, **overrides)
+
+
+def build_v2_packet_route() -> tuple[CoordZXYOffset, AERPacketZXYCopy]:
+    return CoordZXYOffset(1, 1, 1), AERPacketZXYCopy(0, 1, -1)
+
+
+def build_v2_weight_array(
+    size: int,
+    weight_width: int,
+    signed: bool,
+    rng: np.random.Generator,
+    sparse_ratio: float = 0.0,
+) -> np.ndarray:
+    if signed:
+        dtype = np.int8
+        max_value = _mask(weight_width - 1)
+        min_value = -(max_value + 1)
+    else:
+        dtype = np.uint8
+        min_value, max_value = 0, _mask(weight_width)
+
+    weight = rng.integers(min_value, max_value, size=size, dtype=dtype)
+
+    if sparse_ratio > 0 and weight.size > 0:
+        n_zero = int(weight.size * sparse_ratio)
+        if n_zero > 0:
+            indices = rng.choice(weight.size, size=n_zero, replace=False)
+            weight[indices] = 0
+
+    return weight
+
+
+def bit_field(value: int | np.ndarray | np.generic, offset: int, mask: int) -> int:
+    scalar = np.asarray(value).item()
+    return (int(scalar) >> offset) & mask

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0a3"
+version = "2.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "platform_machine == 'armv7l'" },


### PR DESCRIPTION
## Summary
- tighten v2 framelib package generation logic and validation paths
- add clearer public wrappers for config-frame-3 half/full/folded package generation
- improve v2 frame utility typing, payload packing helpers, and destination naming cleanup
- expand v2 model and framelib test coverage with shared fixtures and cleaner test structure
- refresh repo tooling and bump package version to `v2.0.0b1`