### PR TITLE
feat(framelib): add online v2 frame definitions and frame generation

### DIFF
--- a/paicorelib/__init__.py
+++ b/paicorelib/__init__.py
@@ -157,13 +157,14 @@ from .neuron_defs import (
 
 # Chip v2.5
 # Core register definitions & parameters model
-from .core_model_v2 import OfflineCoreRegV2
+from .core_model_v2 import OfflineCoreRegV2, OnlineCoreRegV2
 from .core_defs_v2 import (
     AddPotentialMode,
     CSCAccelerateMode,
     DataSign,
     DataWidth,
     OfflineCoreRegLimV2,
+    OnlineCoreRegLimV2,
     PoolingMode,
     SNNMode,
     ZeroOutputMode,
@@ -177,6 +178,10 @@ from .neuron_model_v2 import (
     OfflineNeuFullAttrsV2Part2,
     OfflineNeuHalfAttrsV2,
     OfflineNeuFullAttrsV2,
+    OnlineNeuDestInfoV2,
+    OnlineNeuHalfAttrsV2,
+    OnlineNeuFullAttrsV2Part1,
+    OnlineNeuFullAttrsV2Part2,
     OfflineNeuFoldedAttrsV2Part1,
     OfflineNeuFoldedAttrsV2Part2,
     OnlineNeuFoldedAttrsV2Part1,
@@ -197,6 +202,7 @@ from .neuron_defs_v2 import (
     LeakAddMode,
     WeightCompressType,
     OfflineNeuRegLimV2,
+    OnlineNeuRegLimV2,
 )
 
 # Routing

--- a/paicorelib/core_defs_v2.py
+++ b/paicorelib/core_defs_v2.py
@@ -5,6 +5,7 @@ from .utils import _mask
 __all__ = [
     # Core reg limits
     "OfflineCoreRegLimV2",
+    "OnlineCoreRegLimV2",
     # Types
     "SNNMode",
     "PoolingMode",
@@ -33,6 +34,21 @@ class OfflineCoreRegLimV2:
     TICK_START_MAX = _mask(16)
     TICK_DURATION_MAX = _mask(32)
     TICK_INITIAL_MAX = _mask(16)
+
+
+class OnlineCoreRegLimV2(OfflineCoreRegLimV2):
+    """Limits of online core registers for chip v2.5."""
+
+    SNN_ANN_MAX = _mask(2)
+    WORK_MODE_MAX = _mask(3)
+    INPUT_CORE_MAX = _mask(1)
+    INPUT_WIDTH_MAX = _mask(2)
+    OUTPUT_CORE_MAX = _mask(1)
+    OUTPUT_WIDTH_MAX = _mask(2)
+    LCN_MAX = _mask(3)
+    TARGET_LCN_MAX = LCN_MAX
+    NEURON_NUMBER_MAX = _mask(13)
+    UPDATE_NUMBER_MAX = _mask(13)
 
 
 @unique

--- a/paicorelib/core_model_v2.py
+++ b/paicorelib/core_model_v2.py
@@ -1,6 +1,13 @@
 from typing import Annotated
 
-from pydantic import Field, NonNegativeInt, PositiveInt, model_validator
+from pydantic import (
+    BeforeValidator,
+    Field,
+    NonNegativeInt,
+    PositiveInt,
+    TypeAdapter,
+    model_validator,
+)
 
 from .core_defs import LCN_EX  # Reuse some types
 from .core_defs_v2 import (
@@ -9,13 +16,30 @@ from .core_defs_v2 import (
     DataSign,
     DataWidth,
     OfflineCoreRegLimV2,
+    OnlineCoreRegLimV2,
     PoolingMode,
     SNNMode,
     ZeroOutputMode,
 )
 from .core_model import CoreReg
 
-__all__ = ["OfflineCoreRegV2"]
+__all__ = ["OfflineCoreRegV2", "OnlineCoreRegV2"]
+
+
+def _to_pooling_mode(value: PoolingMode | int) -> PoolingMode:
+    return PoolingMode(value)
+
+
+def _to_add_potential_mode(value: AddPotentialMode | int) -> AddPotentialMode:
+    return AddPotentialMode(value)
+
+
+def _to_zero_output_mode(value: ZeroOutputMode | int) -> ZeroOutputMode:
+    return ZeroOutputMode(value)
+
+
+def _to_lcn_ex(value: LCN_EX | int) -> LCN_EX:
+    return LCN_EX(value)
 
 
 class OfflineCoreRegV2(CoreReg):
@@ -181,3 +205,239 @@ class OfflineCoreRegV2(CoreReg):
                 self.weight_width = DataWidth.WIDTH_1BIT
 
         return self
+
+
+class OnlineCoreRegV2(CoreReg):
+    """Core parameters model, corresponding to Section 2.3.1 Core Parameters."""
+
+    # Configuration Parameters
+    snn_ann: Annotated[
+        NonNegativeInt,
+        Field(le=OnlineCoreRegLimV2.SNN_ANN_MAX, description="SNN/ANN mode."),
+    ]
+    max_pooling: Annotated[
+        PoolingMode,
+        Field(description="Pooling mode selection."),
+        BeforeValidator(_to_pooling_mode),
+    ]
+    add_potential: Annotated[
+        AddPotentialMode,
+        Field(description="Accumulation mode selection."),
+        BeforeValidator(_to_add_potential_mode),
+    ]
+    zero_output: Annotated[
+        ZeroOutputMode,
+        Field(description="Whether to output zero values."),
+        BeforeValidator(_to_zero_output_mode),
+    ]
+    work_mode: Annotated[
+        NonNegativeInt,
+        Field(le=OnlineCoreRegLimV2.WORK_MODE_MAX, description="Core work mode."),
+    ]
+
+    # Input/Output Selection
+    input_core: Annotated[
+        NonNegativeInt,
+        Field(le=OnlineCoreRegLimV2.INPUT_CORE_MAX, description="Input core type."),
+    ]
+    input_width: Annotated[
+        NonNegativeInt,
+        Field(le=OnlineCoreRegLimV2.INPUT_WIDTH_MAX, description="Input data type."),
+    ]
+    output_core: Annotated[
+        NonNegativeInt,
+        Field(le=OnlineCoreRegLimV2.OUTPUT_CORE_MAX, description="Output core type."),
+    ]
+    output_width: Annotated[
+        NonNegativeInt,
+        Field(le=OnlineCoreRegLimV2.OUTPUT_WIDTH_MAX, description="Output data type."),
+    ]
+
+    # LCN Configuration
+    LCN_AT: Annotated[
+        LCN_EX,
+        Field(description="Activation LCN."),
+        BeforeValidator(_to_lcn_ex),
+    ]
+    LCN_MP: Annotated[
+        LCN_EX,
+        Field(description="Membrane LCN."),
+        BeforeValidator(_to_lcn_ex),
+    ]
+    LCN_LG: Annotated[
+        LCN_EX,
+        Field(description="Gradient LCN."),
+        BeforeValidator(_to_lcn_ex),
+    ]
+    target_LCN_AT: Annotated[
+        LCN_EX,
+        Field(description="Target activation LCN."),
+        BeforeValidator(_to_lcn_ex),
+    ]
+    target_LCN_MP: Annotated[
+        LCN_EX,
+        Field(description="Target membrane LCN."),
+        BeforeValidator(_to_lcn_ex),
+    ]
+    target_LCN_LG: Annotated[
+        LCN_EX,
+        Field(description="Target gradient LCN."),
+        BeforeValidator(_to_lcn_ex),
+    ]
+
+    # Neuron Parameters
+    axon_skew: Annotated[
+        int,
+        Field(
+            ge=OfflineCoreRegLimV2.AXON_SKEW_MIN,
+            le=OfflineCoreRegLimV2.AXON_SKEW_MAX,
+            description="Axon address offset.",
+        ),
+    ]
+    neuron_number: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OnlineCoreRegLimV2.NEURON_NUMBER_MAX,
+            description="Number of valid neurons.",
+        ),
+    ]
+    update_number: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OnlineCoreRegLimV2.UPDATE_NUMBER_MAX,
+            description="Number of neurons to update.",
+        ),
+    ]
+    csc_accelerate: Annotated[
+        CSCAccelerateMode,
+        Field(description="CSC compressed calculation acceleration mode."),
+    ]
+
+    # BF16 Coefficients
+    scale_in: Annotated[float, Field(description="Input scale coefficient.")]
+    bias_in: Annotated[float, Field(description="Input bias coefficient.")]
+    scale_out: Annotated[float, Field(description="Output scale coefficient.")]
+    bias_out: Annotated[float, Field(description="Output bias coefficient.")]
+    learning_rate: Annotated[float, Field(description="Learning rate.")]
+
+    # Update/Test Frame Addresses (Sign-Magnitude 6-bit: -31 to 31)
+    update_core_xy: Annotated[
+        int,
+        Field(
+            ge=OfflineCoreRegLimV2.TEST_CORE_COORD_MIN,
+            le=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+            description="Relative XY address of the updated core.",
+        ),
+    ]
+    update_core_x: Annotated[
+        int,
+        Field(
+            ge=OfflineCoreRegLimV2.TEST_CORE_COORD_MIN,
+            le=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+            description="Relative X address of the updated core.",
+        ),
+    ]
+    update_core_y: Annotated[
+        int,
+        Field(
+            ge=OfflineCoreRegLimV2.TEST_CORE_COORD_MIN,
+            le=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+            description="Relative Y address of the updated core.",
+        ),
+    ]
+    test_core_xy: Annotated[
+        int,
+        Field(
+            ge=OfflineCoreRegLimV2.TEST_CORE_COORD_MIN,
+            le=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+            description="Relative XY address of the test/control target core.",
+        ),
+    ]
+    test_core_x: Annotated[
+        int,
+        Field(
+            ge=OfflineCoreRegLimV2.TEST_CORE_COORD_MIN,
+            le=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+            description="Relative X address of the test/control target core.",
+        ),
+    ]
+    test_core_y: Annotated[
+        int,
+        Field(
+            ge=OfflineCoreRegLimV2.TEST_CORE_COORD_MIN,
+            le=OfflineCoreRegLimV2.TEST_CORE_COORD_MAX,
+            description="Relative Y address of the test/control target core.",
+        ),
+    ]
+
+    # Global Signals
+    global_send: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OfflineCoreRegLimV2.GLOBAL_SEND_MAX,
+            description="Global signal send direction (local, xy+, xy-, x+, x-, y+, y-).",
+        ),
+    ]
+    global_receive: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OfflineCoreRegLimV2.GLOBAL_RECEIVE_MAX,
+            description="Global signal receive direction (xy+, xy-, x+, x-, y+, y-).",
+        ),
+    ]
+
+    # Thread and Timing
+    thread_number: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OfflineCoreRegLimV2.THREAD_NUMBER_MAX,
+            description="Thread number of the current core.",
+        ),
+    ]
+    busy_cycle: Annotated[
+        PositiveInt,
+        Field(
+            gt=1,
+            le=OfflineCoreRegLimV2.BUSY_CYCLE_MAX,
+            description="Busy signal threshold.",
+        ),
+    ]
+    delay_cycle: Annotated[
+        PositiveInt,
+        Field(
+            gt=1,
+            le=OfflineCoreRegLimV2.DELAY_CYCLE_MAX,
+            description="Control signal delay.",
+        ),
+    ]
+    width_cycle: Annotated[
+        PositiveInt,
+        Field(
+            gt=1,
+            le=OfflineCoreRegLimV2.WIDTH_CYCLE_MAX,
+            description="Control signal width.",
+        ),
+    ]
+
+    # Tick Control
+    tick_start: Annotated[
+        NonNegativeInt,
+        Field(le=OfflineCoreRegLimV2.TICK_START_MAX, description="Start tick."),
+    ]
+    tick_duration: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OfflineCoreRegLimV2.TICK_DURATION_MAX,
+            description="Duration tick.",
+        ),
+    ]
+    tick_initial: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OfflineCoreRegLimV2.TICK_INITIAL_MAX,
+            description="Initial tick.",
+        ),
+    ]
+
+
+OnlineCoreRegV2Checker = TypeAdapter(OnlineCoreRegV2)

--- a/paicorelib/framelib/frame_defs.py
+++ b/paicorelib/framelib/frame_defs.py
@@ -718,7 +718,19 @@ class OnlineTestFrame4Format_Out(_OnlineTestFrameFormat_Out, OnlineConfigFrame4F
 
 
 class FrameFormatV2:
-    """General frame mask & offset."""
+    """General frame mask & offset for chip v2.5.
+
+    Common frame layout:
+        [63:62] : frame type
+        [61:60] : frame subtype
+        [59:54] : core_xy
+        [53:48] : core_x
+        [47:42] : core_y
+        [41:36] : copy_xy
+        [35:30] : copy_x
+        [29:24] : copy_y
+        [23:0]  : payload
+    """
 
     FRAME_LENGTH = 64
     GENERAL_MASK = _mask(FRAME_LENGTH)
@@ -727,8 +739,11 @@ class FrameFormatV2:
     GENERAL_HEADER_OFFSET = 60
     GENERAL_HEADER_MASK = _mask(4)
 
-    GENERAL_FRAME_TYPE_OFFSET = GENERAL_HEADER_OFFSET
-    GENERAL_FRAME_TYPE_MASK = GENERAL_HEADER_MASK
+    GENERAL_FRAME_TYPE_OFFSET = 62
+    GENERAL_FRAME_TYPE_MASK = _mask(2)
+
+    GENERAL_FRAME_SUBTYPE_OFFSET = GENERAL_HEADER_OFFSET
+    GENERAL_FRAME_SUBTYPE_MASK = _mask(2)
 
     # Core address
     GENERAL_CORE_ADDR_OFFSET = 42
@@ -1312,6 +1327,651 @@ class OfflineTestFrame4Format_OutV2(
 
     Data Body: Matches OfflineConfigFrame4FormatV2 (8 Words per entry).
     """
+
+    pass
+
+
+"""Frame format for online cores of chip v2.5"""
+
+
+class OnlineConfigFrame1FormatV2(FFV2):
+    """Online config frame type I. Core Parameter.
+
+    Total payload: 320 bits.
+    Frame #1: Bits [319:256]
+    Frame #2: Bits [255:192]
+    Frame #3: Bits [191:128]
+    Frame #4: Bits [127:64]
+    Frame #5: Bits [63:0]
+    """
+
+    class Word1:
+        """Frame #1, bits [319:256]."""
+
+        SNN_ANN_OFFSET = 62
+        SNN_ANN_MASK = _mask(2)
+
+        MAX_POOLING_OFFSET = 61
+        MAX_POOLING_MASK = _mask(1)
+
+        ADD_POTENTIAL_OFFSET = 60
+        ADD_POTENTIAL_MASK = _mask(1)
+
+        ZERO_OUTPUT_OFFSET = 59
+        ZERO_OUTPUT_MASK = _mask(1)
+
+        WORK_MODE_OFFSET = 56
+        WORK_MODE_MASK = _mask(3)
+
+        INPUT_CORE_OFFSET = 55
+        INPUT_CORE_MASK = _mask(1)
+
+        INPUT_WIDTH_OFFSET = 53
+        INPUT_WIDTH_MASK = _mask(2)
+
+        OUTPUT_CORE_OFFSET = 52
+        OUTPUT_CORE_MASK = _mask(1)
+
+        OUTPUT_WIDTH_OFFSET = 50
+        OUTPUT_WIDTH_MASK = _mask(2)
+
+        LCN_AT_OFFSET = 46
+        LCN_AT_MASK = _mask(4)
+
+        LCN_MP_OFFSET = 42
+        LCN_MP_MASK = _mask(4)
+
+        LCN_LG_OFFSET = 38
+        LCN_LG_MASK = _mask(4)
+
+        TARGET_LCN_AT_OFFSET = 34
+        TARGET_LCN_AT_MASK = _mask(4)
+
+        TARGET_LCN_MP_OFFSET = 30
+        TARGET_LCN_MP_MASK = _mask(4)
+
+        TARGET_LCN_LG_OFFSET = 26
+        TARGET_LCN_LG_MASK = _mask(4)
+
+        AXON_SKEW_OFFSET = 10
+        AXON_SKEW_MASK = _mask(16)
+
+        NEURON_NUMBER_HIGH10_OFFSET = 0
+        NEURON_NUMBER_HIGH10_MASK = _mask(10)
+
+    class Word2:
+        """Frame #2, bits [255:192]."""
+
+        NEURON_NUMBER_LOW3_OFFSET = 61
+        NEURON_NUMBER_LOW3_MASK = _mask(3)
+
+        UPDATE_NUMBER_OFFSET = 48
+        UPDATE_NUMBER_MASK = _mask(13)
+
+        CSC_ACCELERATE_OFFSET = 47
+        CSC_ACCELERATE_MASK = _mask(1)
+
+        SCALE_IN_OFFSET = 31
+        SCALE_IN_MASK = _mask(16)
+
+        BIAS_IN_OFFSET = 15
+        BIAS_IN_MASK = _mask(16)
+
+        SCALE_OUT_HIGH15_OFFSET = 0
+        SCALE_OUT_HIGH15_MASK = _mask(15)
+
+    class Word3:
+        """Frame #3, bits [191:128]."""
+
+        SCALE_OUT_LOW1_OFFSET = 63
+        SCALE_OUT_LOW1_MASK = _mask(1)
+
+        BIAS_OUT_OFFSET = 47
+        BIAS_OUT_MASK = _mask(16)
+
+        LEARNING_RATE_OFFSET = 31
+        LEARNING_RATE_MASK = _mask(16)
+
+        UPDATE_CORE_XY_OFFSET = 25
+        UPDATE_CORE_XY_MASK = _mask(6)
+
+        UPDATE_CORE_X_OFFSET = 19
+        UPDATE_CORE_X_MASK = _mask(6)
+
+        UPDATE_CORE_Y_OFFSET = 13
+        UPDATE_CORE_Y_MASK = _mask(6)
+
+        TEST_CORE_XY_OFFSET = 7
+        TEST_CORE_XY_MASK = _mask(6)
+
+        TEST_CORE_X_OFFSET = 1
+        TEST_CORE_X_MASK = _mask(6)
+
+        TEST_CORE_Y_HIGH1_OFFSET = 0
+        TEST_CORE_Y_HIGH1_MASK = _mask(1)
+
+    class Word4:
+        """Frame #4, bits [127:64]."""
+
+        TEST_CORE_Y_LOW5_OFFSET = 59
+        TEST_CORE_Y_LOW5_MASK = _mask(5)
+
+        GLOBAL_SEND_OFFSET = 52
+        GLOBAL_SEND_MASK = _mask(7)
+
+        GLOBAL_RECEIVE_OFFSET = 46
+        GLOBAL_RECEIVE_MASK = _mask(6)
+
+        THREAD_NUMBER_OFFSET = 36
+        THREAD_NUMBER_MASK = _mask(10)
+
+        BUSY_CYCLE_OFFSET = 24
+        BUSY_CYCLE_MASK = _mask(12)
+
+        DELAY_CYCLE_OFFSET = 8
+        DELAY_CYCLE_MASK = _mask(16)
+
+        WIDTH_CYCLE_OFFSET = 0
+        WIDTH_CYCLE_MASK = _mask(8)
+
+    class Word5:
+        """Frame #5, bits [63:0]."""
+
+        TICK_START_OFFSET = 48
+        TICK_START_MASK = _mask(16)
+
+        TICK_DURATION_OFFSET = 16
+        TICK_DURATION_MASK = _mask(32)
+
+        TICK_INITIAL_OFFSET = 0
+        TICK_INITIAL_MASK = _mask(16)
+
+
+class OnlineConfigFrame2FormatV2(FFV2):
+    """Online config frame type II. LUT SRAM.
+
+    potential: 32 bits
+    activation: 16 bits
+
+    Frame #1: 16'd0, potential[0], activation[0]
+    ...
+    Frame #256: 16'd0, potential[255], activation[255]
+    """
+
+    RESERVED_OFFSET = 48
+    RESERVED_MASK = _mask(16)
+
+    POTENTIAL_OFFSET = 16
+    POTENTIAL_MASK = _mask(32)
+
+    ACTIVATION_OFFSET = 0
+    ACTIVATION_MASK = _mask(16)
+
+    RAM0_OFFSET = POTENTIAL_OFFSET
+    RAM0_MASK = POTENTIAL_MASK
+    RAM1_OFFSET = ACTIVATION_OFFSET
+    RAM1_MASK = ACTIVATION_MASK
+
+
+class OnlineConfigFrame3FormatV2(FFV2):
+    """Online config frame type III. Neuron SRAM.
+
+    RAM: 4096 x 128 bits
+    Configure from parameter LSB in little-endian word order.
+
+    Frame #1: RAM[0][63:0]
+    Frame #2: RAM[0][127:64]
+    Frame #3: RAM[1][63:0]
+    ...
+    Frame #8192: RAM[4095][127:64]
+    """
+
+    N_FRAME_PER_RAM_ADDR = 2
+
+    class Full:
+        class Word1:
+            WEIGHT_SKEW_LOW4_OFFSET = 60
+            WEIGHT_SKEW_LOW4_MASK = _mask(4)
+
+            WEIGHT_ADDRESS_START_OFFSET = 48
+            WEIGHT_ADDRESS_START_MASK = _mask(12)
+
+            WEIGHT_ADDRESS_END_OFFSET = 36
+            WEIGHT_ADDRESS_END_MASK = _mask(12)
+
+            OUTPUT_TYPE_OFFSET = 34
+            OUTPUT_TYPE_MASK = _mask(2)
+
+            FOLD_TYPE_OFFSET = 33
+            FOLD_TYPE_MASK = _mask(1)
+
+            NEURON_TYPE_OFFSET = 32
+            NEURON_TYPE_MASK = _mask(1)
+
+            VJT_OFFSET = 0
+            VJT_MASK = _mask(32)
+
+        class Word2:
+            TICK_RELATIVE_OFFSET = 56
+            TICK_RELATIVE_MASK = _mask(8)
+
+            ADDR_AXON_OFFSET = 48
+            ADDR_AXON_MASK = _mask(8)
+
+            ADDR_CORE_XY_OFFSET = 42
+            ADDR_CORE_XY_MASK = _mask(6)
+
+            ADDR_CORE_X_OFFSET = 36
+            ADDR_CORE_X_MASK = _mask(6)
+
+            ADDR_CORE_Y_OFFSET = 30
+            ADDR_CORE_Y_MASK = _mask(6)
+
+            ADDR_COPY_XY_OFFSET = 24
+            ADDR_COPY_XY_MASK = _mask(6)
+
+            ADDR_COPY_X_OFFSET = 18
+            ADDR_COPY_X_MASK = _mask(6)
+
+            ADDR_COPY_Y_OFFSET = 12
+            ADDR_COPY_Y_MASK = _mask(6)
+
+            WEIGHT_SKEW_HIGH12_OFFSET = 0
+            WEIGHT_SKEW_HIGH12_MASK = _mask(12)
+
+        class Word3:
+            THRESHOLD_POS_LOW20_OFFSET = 44
+            THRESHOLD_POS_LOW20_MASK = _mask(20)
+
+            LATERAL_INHIBITION_OFFSET = 43
+            LATERAL_INHIBITION_MASK = _mask(1)
+
+            LEAK_MULTI_SEQUENCE_OFFSET = 42
+            LEAK_MULTI_SEQUENCE_MASK = _mask(1)
+
+            LEAK_MULTI_INPUT_OFFSET = 41
+            LEAK_MULTI_INPUT_MASK = _mask(1)
+
+            LEAK_MULTI_MODE_OFFSET = 40
+            LEAK_MULTI_MODE_MASK = _mask(1)
+
+            LEAK_ADD_MODE_OFFSET = 39
+            LEAK_ADD_MODE_MASK = _mask(1)
+
+            LEAK_TAU_OFFSET = 33
+            LEAK_TAU_MASK = _mask(6)
+
+            VJT_INITIAL_OFFSET = 17
+            VJT_INITIAL_MASK = _mask(16)
+
+            WEIGHT_COMPRESS_OFFSET = 16
+            WEIGHT_COMPRESS_MASK = _mask(1)
+
+            LEAK_V_OFFSET = 0
+            LEAK_V_MASK = _mask(16)
+
+        class Word4:
+            RESET_MODE_OFFSET = 62
+            RESET_MODE_MASK = _mask(2)
+
+            RESET_V_OFFSET = 46
+            RESET_V_MASK = _mask(16)
+
+            THRESHOLD_NEG_MODE_OFFSET = 45
+            THRESHOLD_NEG_MODE_MASK = _mask(1)
+
+            THRESHOLD_POS_MODE_OFFSET = 44
+            THRESHOLD_POS_MODE_MASK = _mask(1)
+
+            THRESHOLD_NEG_OFFSET = 12
+            THRESHOLD_NEG_MASK = _mask(32)
+
+            THRESHOLD_POS_HIGH12_OFFSET = 0
+            THRESHOLD_POS_HIGH12_MASK = _mask(12)
+
+    class Fold:
+        class Word1:
+            FOLD_SKEW_Y_LOW2_OFFSET = 62
+            FOLD_SKEW_Y_LOW2_MASK = _mask(2)
+
+            FOLD_AXON_XY_OFFSET = 51
+            FOLD_AXON_XY_MASK = _mask(11)
+
+            FOLD_AXON_X_OFFSET = 40
+            FOLD_AXON_X_MASK = _mask(11)
+
+            FOLD_AXON_Y_OFFSET = 29
+            FOLD_AXON_Y_MASK = _mask(11)
+
+            FOLD_NUMBER_OFFSET = 0
+            FOLD_NUMBER_MASK = _mask(29)
+
+        class Word2:
+            FOLD_RANGE_XY_OFFSET = 53
+            FOLD_RANGE_XY_MASK = _mask(11)
+
+            FOLD_RANGE_X_OFFSET = 42
+            FOLD_RANGE_X_MASK = _mask(11)
+
+            FOLD_RANGE_Y_OFFSET = 31
+            FOLD_RANGE_Y_MASK = _mask(11)
+
+            FOLD_SKEW_XY_OFFSET = 20
+            FOLD_SKEW_XY_MASK = _mask(11)
+
+            FOLD_SKEW_X_OFFSET = 9
+            FOLD_SKEW_X_MASK = _mask(11)
+
+            FOLD_SKEW_Y_HIGH9_OFFSET = 0
+            FOLD_SKEW_Y_HIGH9_MASK = _mask(9)
+
+        class Word3:
+            FOLD_VJT_1_OFFSET = 32
+            FOLD_VJT_1_MASK = _mask(32)
+
+            FOLD_VJT_0_OFFSET = 0
+            FOLD_VJT_0_MASK = _mask(32)
+
+        class Word4:
+            FOLD_VJT_3_OFFSET = 32
+            FOLD_VJT_3_MASK = _mask(32)
+
+            FOLD_VJT_2_OFFSET = 0
+            FOLD_VJT_2_MASK = _mask(32)
+
+    class WeightDense:
+        class Word1:
+            WEIGHT_3_OFFSET = 48
+            WEIGHT_3_MASK = _mask(16)
+
+            WEIGHT_2_OFFSET = 32
+            WEIGHT_2_MASK = _mask(16)
+
+            WEIGHT_1_OFFSET = 16
+            WEIGHT_1_MASK = _mask(16)
+
+            WEIGHT_0_OFFSET = 0
+            WEIGHT_0_MASK = _mask(16)
+
+        class Word2:
+            WEIGHT_7_OFFSET = 48
+            WEIGHT_7_MASK = _mask(16)
+
+            WEIGHT_6_OFFSET = 32
+            WEIGHT_6_MASK = _mask(16)
+
+            WEIGHT_5_OFFSET = 16
+            WEIGHT_5_MASK = _mask(16)
+
+            WEIGHT_4_OFFSET = 0
+            WEIGHT_4_MASK = _mask(16)
+
+    class WeightCSC:
+        class Word1:
+            WEIGHT_3_OFFSET = 48
+            WEIGHT_3_MASK = _mask(16)
+
+            WEIGHT_2_OFFSET = 32
+            WEIGHT_2_MASK = _mask(16)
+
+            WEIGHT_1_OFFSET = 16
+            WEIGHT_1_MASK = _mask(16)
+
+            WEIGHT_0_OFFSET = 0
+            WEIGHT_0_MASK = _mask(16)
+
+        class Word2:
+            WEIGHT_INDICE_3_OFFSET = 48
+            WEIGHT_INDICE_3_MASK = _mask(16)
+
+            WEIGHT_INDICE_2_OFFSET = 32
+            WEIGHT_INDICE_2_MASK = _mask(16)
+
+            WEIGHT_INDICE_1_OFFSET = 16
+            WEIGHT_INDICE_1_MASK = _mask(16)
+
+            WEIGHT_INDICE_0_OFFSET = 0
+            WEIGHT_INDICE_0_MASK = _mask(16)
+
+
+class OnlineConfigFrame4FormatV2(FFV2):
+    """Online config frame type IV. Input SRAM.
+
+    RAM: 256 x 256 bits
+    Configure from parameter LSB.
+
+    Frame #1: RAM[0][63:0]
+    Frame #2: RAM[0][127:64]
+    Frame #3: RAM[0][191:128]
+    Frame #4: RAM[0][255:192]
+    ...
+    Frame #1024: RAM[255][255:192]
+    """
+
+    N_FRAME_PER_RAM_ADDR = 4
+
+
+OnlineCoreRegFormatV2 = OnlineConfigFrame1FormatV2
+OnlineLutRAMFormatV2 = OnlineConfigFrame2FormatV2
+OnlineNeuRAMFormatV2 = OnlineConfigFrame3FormatV2
+OnlineInputRAMFormatV2 = OnlineConfigFrame4FormatV2
+
+
+class OnlineWorkFrame1FormatV2(FFV2):
+    """Work frame type I. Data.
+
+    Payload layout:
+        [23:16] : Time Step
+        [15:8]  : Axon address
+        [7:0]   : Data
+
+    NOTE: The effective widths of Time Step and Axon address vary with LCN.
+    """
+
+    # Time step and axon address share 16 bits and vary with LCN:
+    # 8:8, 7:9, 6:10, 5:11, 4:12, 3:13, 2:14, 1:15, 0:16
+    LCN_TO_TS_AXON_WIDTHS = (
+        (8, 8),
+        (7, 9),
+        (6, 10),
+        (5, 11),
+        (4, 12),
+        (3, 13),
+        (2, 14),
+        (1, 15),
+        (0, 16),
+    )
+
+    TIMESTEP_AXON_OFFSET = 8
+    TIMESTEP_AXON_MASK = _mask(16)
+
+    TIMESTEP_OFFSET = 16
+    TIMESTEP_MASK = _mask(8)
+
+    AXON_ADDR_OFFSET = 8
+    AXON_ADDR_MASK = _mask(8)
+
+    DATA_OFFSET = 0
+    DATA_MASK = _mask(8)
+
+
+class OnlineWorkFrame2FormatV2(FFV2):
+    """Work frame type II. Data Gradient.
+
+    Payload layout is identical to work frame type I.
+    """
+
+    LCN_TO_TS_AXON_WIDTHS = OnlineWorkFrame1FormatV2.LCN_TO_TS_AXON_WIDTHS
+
+    TIMESTEP_AXON_OFFSET = OnlineWorkFrame1FormatV2.TIMESTEP_AXON_OFFSET
+    TIMESTEP_AXON_MASK = OnlineWorkFrame1FormatV2.TIMESTEP_AXON_MASK
+
+    TIMESTEP_OFFSET = OnlineWorkFrame1FormatV2.TIMESTEP_OFFSET
+    TIMESTEP_MASK = OnlineWorkFrame1FormatV2.TIMESTEP_MASK
+
+    AXON_ADDR_OFFSET = OnlineWorkFrame1FormatV2.AXON_ADDR_OFFSET
+    AXON_ADDR_MASK = OnlineWorkFrame1FormatV2.AXON_ADDR_MASK
+
+    DATA_OFFSET = OnlineWorkFrame1FormatV2.DATA_OFFSET
+    DATA_MASK = OnlineWorkFrame1FormatV2.DATA_MASK
+
+
+class OnlineWorkFrame3FormatV2(FFV2):
+    """Work frame type III. Membrane Potential.
+
+    Payload layout is identical to work frame type I.
+    """
+
+    LCN_TO_TS_AXON_WIDTHS = OnlineWorkFrame1FormatV2.LCN_TO_TS_AXON_WIDTHS
+
+    TIMESTEP_AXON_OFFSET = OnlineWorkFrame1FormatV2.TIMESTEP_AXON_OFFSET
+    TIMESTEP_AXON_MASK = OnlineWorkFrame1FormatV2.TIMESTEP_AXON_MASK
+
+    TIMESTEP_OFFSET = OnlineWorkFrame1FormatV2.TIMESTEP_OFFSET
+    TIMESTEP_MASK = OnlineWorkFrame1FormatV2.TIMESTEP_MASK
+
+    AXON_ADDR_OFFSET = OnlineWorkFrame1FormatV2.AXON_ADDR_OFFSET
+    AXON_ADDR_MASK = OnlineWorkFrame1FormatV2.AXON_ADDR_MASK
+
+    DATA_OFFSET = OnlineWorkFrame1FormatV2.DATA_OFFSET
+    DATA_MASK = OnlineWorkFrame1FormatV2.DATA_MASK
+
+    VJT_OFFSET = DATA_OFFSET
+    VJT_MASK = DATA_MASK
+
+
+class OnlineWorkFrame4FormatV2(FFV2):
+    """Work frame type IV. Membrane Potential Gradient.
+
+    Payload layout is identical to work frame type I.
+    """
+
+    LCN_TO_TS_AXON_WIDTHS = OnlineWorkFrame1FormatV2.LCN_TO_TS_AXON_WIDTHS
+
+    TIMESTEP_AXON_OFFSET = OnlineWorkFrame1FormatV2.TIMESTEP_AXON_OFFSET
+    TIMESTEP_AXON_MASK = OnlineWorkFrame1FormatV2.TIMESTEP_AXON_MASK
+
+    TIMESTEP_OFFSET = OnlineWorkFrame1FormatV2.TIMESTEP_OFFSET
+    TIMESTEP_MASK = OnlineWorkFrame1FormatV2.TIMESTEP_MASK
+
+    AXON_ADDR_OFFSET = OnlineWorkFrame1FormatV2.AXON_ADDR_OFFSET
+    AXON_ADDR_MASK = OnlineWorkFrame1FormatV2.AXON_ADDR_MASK
+
+    DATA_OFFSET = OnlineWorkFrame1FormatV2.DATA_OFFSET
+    DATA_MASK = OnlineWorkFrame1FormatV2.DATA_MASK
+
+
+class OnlineControlFrame1FormatV2(FFV2):
+    """Control frame type I. Sync."""
+
+    NUM_TIMESTEP_OFFSET = 0
+    NUM_TIMESTEP_MASK = _mask(24)
+
+
+class OnlineControlFrame2FormatV2(FFV2):
+    """Control frame type II. Init."""
+
+    RESERVED_OFFSET = 0
+    RESERVED_MASK = _mask(24)
+
+
+class OnlineControlFrame3FormatV2(FFV2):
+    """Control frame type III. Complete."""
+
+    THREAD_ID_OFFSET = 0
+    THREAD_ID_MASK = _mask(24)
+
+
+class OnlineControlFrame4FormatV2(FFV2):
+    """Control frame type IV. Update."""
+
+    EXT_MULTICAST_ADDR_OFFSET = 0
+    EXT_MULTICAST_ADDR_MASK = _mask(18)
+
+    RESERVED_OFFSET = 18
+    RESERVED_MASK = _mask(6)
+
+
+class _OnlineTestFrameFormat_InV2(_TestFrameFormat_InV2):
+    """General online test input frame format (Read Request)."""
+
+    TEST_PKT_TYPE_VAL = FramePackageType.TESTIN
+
+
+class _OnlineTestFrameFormat_OutV2(_TestFrameFormat_OutV2):
+    """General online test output frame format (Read Response)."""
+
+    TEST_PKT_TYPE_VAL = FramePackageType.CONF_TESTOUT
+
+
+class OnlineTestFrame1Format_InV2(_OnlineTestFrameFormat_InV2):
+    """Test frame type I. Core Registers, Input (Request)."""
+
+    RESERVED_OFFSET = 14
+    RESERVED_MASK = _mask(9)
+
+    PACKAGE_NUM_OFFSET = 0
+    PACKAGE_NUM_MASK = _mask(14)
+
+
+class OnlineTestFrame1Format_OutV2(
+    _OnlineTestFrameFormat_OutV2, OnlineConfigFrame1FormatV2
+):
+    """Test frame type I. Core Registers, Output (Response)."""
+
+    pass
+
+
+class OnlineTestFrame2Format_InV2(_OnlineTestFrameFormat_InV2):
+    """Test frame type II. LUT SRAM, Input (Request)."""
+
+    SRAM_START_ADDR_OFFSET = 14
+    SRAM_START_ADDR_MASK = _mask(9)
+
+    PACKAGE_NUM_OFFSET = 0
+    PACKAGE_NUM_MASK = _mask(14)
+
+
+class OnlineTestFrame2Format_OutV2(
+    _OnlineTestFrameFormat_OutV2, OnlineConfigFrame2FormatV2
+):
+    """Test frame type II. LUT SRAM, Output (Response)."""
+
+    pass
+
+
+class OnlineTestFrame3Format_InV2(_OnlineTestFrameFormat_InV2):
+    """Test frame type III. Neuron SRAM, Input (Request)."""
+
+    SRAM_START_ADDR_DIV8_OFFSET = 14
+    SRAM_START_ADDR_DIV8_MASK = _mask(9)
+
+    PACKAGE_NUM_OFFSET = 0
+    PACKAGE_NUM_MASK = _mask(14)
+
+
+class OnlineTestFrame3Format_OutV2(
+    _OnlineTestFrameFormat_OutV2, OnlineConfigFrame3FormatV2
+):
+    """Test frame type III. Neuron SRAM, Output (Response)."""
+
+    pass
+
+
+class OnlineTestFrame4Format_InV2(_OnlineTestFrameFormat_InV2):
+    """Test frame type IV. Input SRAM, Input (Request)."""
+
+    SRAM_START_ADDR_OFFSET = 14
+    SRAM_START_ADDR_MASK = _mask(9)
+
+    PACKAGE_NUM_OFFSET = 0
+    PACKAGE_NUM_MASK = _mask(14)
+
+
+class OnlineTestFrame4Format_OutV2(
+    _OnlineTestFrameFormat_OutV2, OnlineConfigFrame4FormatV2
+):
+    """Test frame type IV. Input SRAM, Output (Response)."""
 
     pass
 

--- a/paicorelib/framelib/frame_gen_v2.py
+++ b/paicorelib/framelib/frame_gen_v2.py
@@ -10,7 +10,7 @@ from paicorelib.framelib.frames import NDArray
 from ..coordinate import CoordZXYOffset, coordzxy_to_sign_magnitude
 from ..core_defs import LCN_EX
 from ..core_defs_v2 import CSCAccelerateMode, DataWidth
-from ..core_model_v2 import OfflineCoreRegV2
+from ..core_model_v2 import OfflineCoreRegV2, OnlineCoreRegV2
 from ..neuron_model_v2 import (
     OfflineNeuDestInfoV2,
     OfflineNeuFoldedAttrsV2Part1,
@@ -18,6 +18,12 @@ from ..neuron_model_v2 import (
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
     OfflineNeuHalfAttrsV2,
+    OnlineNeuDestInfoV2,
+    OnlineNeuFoldedAttrsV2Part1,
+    OnlineNeuFoldedAttrsV2Part2,
+    OnlineNeuFullAttrsV2Part1,
+    OnlineNeuFullAttrsV2Part2,
+    OnlineNeuHalfAttrsV2,
 )
 from ..routing_hexa import AERPacketZXYCopy
 from .base import FramePackageHeaderV2, FrameV2, get_frame_dest_v2
@@ -29,6 +35,16 @@ from .frame_defs import OfflineConfigFrame3FormatV2 as Off_Cfg3_V2
 from .frame_defs import OfflineControlFrame1FormatV2 as Off_Ctrl1_V2
 from .frame_defs import OfflineControlFrame3FormatV2 as Off_Ctrl3_V2
 from .frame_defs import OfflineWorkFrame1FormatV2 as Off_Work1_V2
+from .frame_defs import OnlineConfigFrame1FormatV2 as On_Cfg1_V2
+from .frame_defs import OnlineConfigFrame2FormatV2 as On_Cfg2_V2
+from .frame_defs import OnlineConfigFrame3FormatV2 as On_Cfg3_V2
+from .frame_defs import OnlineControlFrame1FormatV2 as On_Ctrl1_V2
+from .frame_defs import OnlineControlFrame3FormatV2 as On_Ctrl3_V2
+from .frame_defs import OnlineControlFrame4FormatV2 as On_Ctrl4_V2
+from .frame_defs import OnlineWorkFrame1FormatV2 as On_Work1_V2
+from .frame_defs import OnlineWorkFrame2FormatV2 as On_Work2_V2
+from .frame_defs import OnlineWorkFrame3FormatV2 as On_Work3_V2
+from .frame_defs import OnlineWorkFrame4FormatV2 as On_Work4_V2
 from .types import (
     FRAME_DTYPE,
     PAYLOAD_DATA_DTYPE,
@@ -38,12 +54,24 @@ from .types import (
 )
 from .utils import _mask, bin_split, pack_field
 
-__all__ = ["FrameGenV2", "OfflineFrameGenV2"]
+__all__ = ["FrameGenV2", "OfflineFrameGenV2", "OnlineFrameGenV2"]
 
 DataWidthLE8 = Literal[1, 2, 4, 8]
 DataWidthLE8Like = DataWidth | DataWidthLE8
 
 _p = pack_field
+
+_UINT_DTYPE_BY_BITS = {
+    8: np.uint8,
+    16: np.uint16,
+    32: np.uint32,
+    64: np.uint64,
+}
+_FLOAT_DTYPE_BY_BITS = {
+    16: np.float16,
+    32: np.float32,
+    64: np.float64,
+}
 
 
 def _normalize_width_le8(
@@ -55,6 +83,87 @@ def _normalize_width_le8(
         raise ValueError(f"'{name}' only supports 1/2/4/8-bit widths, got {width}.")
 
     return cast(DataWidthLE8, width_bits)
+
+
+def _array_to_bits(values: ArrayLike, nbits: Literal[8, 16, 32, 64]) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+
+    if np.issubdtype(arr.dtype, np.floating):
+        float_dtype = np.dtype(_FLOAT_DTYPE_BY_BITS[nbits]).newbyteorder("<")
+        uint_dtype = np.dtype(_UINT_DTYPE_BY_BITS[nbits]).newbyteorder("<")
+        return arr.astype(float_dtype, copy=False).view(uint_dtype)
+
+    return arr.astype(_UINT_DTYPE_BY_BITS[nbits], copy=False)
+
+
+def _value_to_bits(value: Any, nbits: Literal[8, 16, 32, 64]) -> int:
+    return int(_array_to_bits([value], nbits)[0])
+
+
+def _array_to_bf16_bits(values: ArrayLike) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+
+    if np.issubdtype(arr.dtype, np.floating):
+        float_dtype = np.dtype(np.float32).newbyteorder("<")
+        uint_dtype = np.dtype(np.uint32).newbyteorder("<")
+        arr_f32 = np.ascontiguousarray(arr.astype(float_dtype, copy=False))
+        return (arr_f32.view(uint_dtype) >> 16).astype(np.uint16, copy=False)
+
+    return arr.astype(np.uint16, copy=False)
+
+
+def _value_to_bf16_bits(value: Any) -> int:
+    return int(_array_to_bf16_bits([value])[0])
+
+
+def _normalize_online_lcn(target_lcn: int | LCN_EX) -> int:
+    lcn = target_lcn.value if isinstance(target_lcn, LCN_EX) else int(target_lcn)
+    if lcn < 0 or lcn >= len(On_Work1_V2.LCN_TO_TS_AXON_WIDTHS):
+        raise ValueError(f"'target_lcn' out of range [0, 8], got {target_lcn}.")
+
+    return lcn
+
+
+def _normalize_online_work_data(data: ArrayLike) -> np.ndarray:
+    arr = np.asarray(data)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+
+    if arr.dtype.kind == "f":
+        if arr.dtype.itemsize not in (2, 4):
+            arr = arr.astype(np.float32)
+    elif arr.dtype.kind == "b":
+        arr = arr.astype(np.uint8, copy=False)
+    elif arr.dtype.kind in "iu":
+        if arr.dtype.itemsize not in (1, 2, 4):
+            if arr.size == 0:
+                arr = arr.astype(np.uint8)
+            elif arr.dtype.kind == "u":
+                vmax = int(arr.max())
+                if vmax <= _mask(8):
+                    arr = arr.astype(np.uint8)
+                elif vmax <= _mask(16):
+                    arr = arr.astype(np.uint16)
+                else:
+                    arr = arr.astype(np.uint32)
+            else:
+                vmin = int(arr.min())
+                vmax = int(arr.max())
+                if np.iinfo(np.int8).min <= vmin and vmax <= np.iinfo(np.int8).max:
+                    arr = arr.astype(np.int8)
+                elif np.iinfo(np.int16).min <= vmin and vmax <= np.iinfo(np.int16).max:
+                    arr = arr.astype(np.int16)
+                else:
+                    arr = arr.astype(np.int32)
+    else:
+        raise TypeError(f"unsupported dtype for online work data: {arr.dtype}.")
+
+    arr = np.ascontiguousarray(arr.astype(arr.dtype.newbyteorder("<"), copy=False))
+    return arr.view(np.uint8).reshape(arr.size, arr.dtype.itemsize)
 
 
 class FrameGenV2:
@@ -420,18 +529,16 @@ class OfflineFrameGenV2(FrameGenV2):
         if len(folded_attrs2_) == 0:
             raise ValueError("attributes of folded neuron are incomplete")
 
-        folded_attrs1_dump = OfflineNeuFoldedAttrsV2Part1.model_validate(
+        folded_attrs1 = OfflineNeuFoldedAttrsV2Part1.model_validate(
             folded_attrs1, strict=True
         ).model_dump()
-        folded_attrs2_dump = [
+        folded_attrs2 = [
             OfflineNeuFoldedAttrsV2Part2.model_validate(
                 attrs2, strict=True
             ).model_dump()
             for attrs2 in folded_attrs2_
         ]
-        return OfflineFrameGenV2._gen_pkg_folded_neu(
-            folded_attrs1_dump, *folded_attrs2_dump
-        )
+        return OfflineFrameGenV2._gen_pkg_folded_neu(folded_attrs1, *folded_attrs2)
 
     @staticmethod
     def _gen_pkg_half_neu(
@@ -797,10 +904,960 @@ class OfflineFrameGenV2(FrameGenV2):
         return FrameV2(FH.CTRL_TYPE3, pkt_offset, pkt_ncopy, thread_id).value
 
 
+class OnlineFrameGenV2(FrameGenV2):
+    LCN_TO_TS_AXON_WIDTHS = On_Work1_V2.LCN_TO_TS_AXON_WIDTHS
+
+    @staticmethod
+    def gen_config_frame1(
+        pkt_offset: CoordZXYOffset,
+        core_reg_: OnlineCoreRegV2 | dict[str, Any],
+        pkt_ncopy: AERPacketZXYCopy = AERPacketZXYCopy(),
+        start_addr: int = 0,
+    ) -> FrameArrayType:
+        F = On_Cfg1_V2
+        core_reg = OnlineCoreRegV2.model_validate(core_reg_, strict=True).model_dump()
+
+        neuron_number_h10, neuron_number_l3 = bin_split(
+            int(core_reg["neuron_number"]), 3, 10
+        )
+        scale_out_bits = _value_to_bf16_bits(core_reg["scale_out"])
+        scale_out_h15, scale_out_l1 = bin_split(scale_out_bits, 1, 15)
+        update_core_xy, update_core_x, update_core_y = coordzxy_to_sign_magnitude(
+            (
+                int(core_reg["update_core_xy"]),
+                int(core_reg["update_core_x"]),
+                int(core_reg["update_core_y"]),
+            )
+        )
+        test_core_xy, test_core_x, test_core_y = coordzxy_to_sign_magnitude(
+            (
+                int(core_reg["test_core_xy"]),
+                int(core_reg["test_core_x"]),
+                int(core_reg["test_core_y"]),
+            )
+        )
+        test_core_y_h1, test_core_y_l5 = bin_split(test_core_y, 5, 1)
+
+        w1 = (
+            _p(core_reg["snn_ann"], F.Word1.SNN_ANN_OFFSET, F.Word1.SNN_ANN_MASK)
+            | _p(
+                core_reg["max_pooling"],
+                F.Word1.MAX_POOLING_OFFSET,
+                F.Word1.MAX_POOLING_MASK,
+            )
+            | _p(
+                core_reg["add_potential"],
+                F.Word1.ADD_POTENTIAL_OFFSET,
+                F.Word1.ADD_POTENTIAL_MASK,
+            )
+            | _p(
+                core_reg["zero_output"],
+                F.Word1.ZERO_OUTPUT_OFFSET,
+                F.Word1.ZERO_OUTPUT_MASK,
+            )
+            | _p(
+                core_reg["work_mode"], F.Word1.WORK_MODE_OFFSET, F.Word1.WORK_MODE_MASK
+            )
+            | _p(
+                core_reg["input_core"],
+                F.Word1.INPUT_CORE_OFFSET,
+                F.Word1.INPUT_CORE_MASK,
+            )
+            | _p(
+                core_reg["input_width"],
+                F.Word1.INPUT_WIDTH_OFFSET,
+                F.Word1.INPUT_WIDTH_MASK,
+            )
+            | _p(
+                core_reg["output_core"],
+                F.Word1.OUTPUT_CORE_OFFSET,
+                F.Word1.OUTPUT_CORE_MASK,
+            )
+            | _p(
+                core_reg["output_width"],
+                F.Word1.OUTPUT_WIDTH_OFFSET,
+                F.Word1.OUTPUT_WIDTH_MASK,
+            )
+            | _p(core_reg["LCN_AT"], F.Word1.LCN_AT_OFFSET, F.Word1.LCN_AT_MASK)
+            | _p(core_reg["LCN_MP"], F.Word1.LCN_MP_OFFSET, F.Word1.LCN_MP_MASK)
+            | _p(core_reg["LCN_LG"], F.Word1.LCN_LG_OFFSET, F.Word1.LCN_LG_MASK)
+            | _p(
+                core_reg["target_LCN_AT"],
+                F.Word1.TARGET_LCN_AT_OFFSET,
+                F.Word1.TARGET_LCN_AT_MASK,
+            )
+            | _p(
+                core_reg["target_LCN_MP"],
+                F.Word1.TARGET_LCN_MP_OFFSET,
+                F.Word1.TARGET_LCN_MP_MASK,
+            )
+            | _p(
+                core_reg["target_LCN_LG"],
+                F.Word1.TARGET_LCN_LG_OFFSET,
+                F.Word1.TARGET_LCN_LG_MASK,
+            )
+            | _p(
+                core_reg["axon_skew"], F.Word1.AXON_SKEW_OFFSET, F.Word1.AXON_SKEW_MASK
+            )
+            | _p(
+                neuron_number_h10,
+                F.Word1.NEURON_NUMBER_HIGH10_OFFSET,
+                F.Word1.NEURON_NUMBER_HIGH10_MASK,
+            )
+        )
+        w2 = (
+            _p(
+                neuron_number_l3,
+                F.Word2.NEURON_NUMBER_LOW3_OFFSET,
+                F.Word2.NEURON_NUMBER_LOW3_MASK,
+            )
+            | _p(
+                core_reg["update_number"],
+                F.Word2.UPDATE_NUMBER_OFFSET,
+                F.Word2.UPDATE_NUMBER_MASK,
+            )
+            | _p(
+                core_reg["csc_accelerate"],
+                F.Word2.CSC_ACCELERATE_OFFSET,
+                F.Word2.CSC_ACCELERATE_MASK,
+            )
+            | _p(
+                _value_to_bf16_bits(core_reg["scale_in"]),
+                F.Word2.SCALE_IN_OFFSET,
+                F.Word2.SCALE_IN_MASK,
+            )
+            | _p(
+                _value_to_bf16_bits(core_reg["bias_in"]),
+                F.Word2.BIAS_IN_OFFSET,
+                F.Word2.BIAS_IN_MASK,
+            )
+            | _p(
+                scale_out_h15,
+                F.Word2.SCALE_OUT_HIGH15_OFFSET,
+                F.Word2.SCALE_OUT_HIGH15_MASK,
+            )
+        )
+        w3 = (
+            _p(
+                scale_out_l1,
+                F.Word3.SCALE_OUT_LOW1_OFFSET,
+                F.Word3.SCALE_OUT_LOW1_MASK,
+            )
+            | _p(
+                _value_to_bf16_bits(core_reg["bias_out"]),
+                F.Word3.BIAS_OUT_OFFSET,
+                F.Word3.BIAS_OUT_MASK,
+            )
+            | _p(
+                _value_to_bf16_bits(core_reg["learning_rate"]),
+                F.Word3.LEARNING_RATE_OFFSET,
+                F.Word3.LEARNING_RATE_MASK,
+            )
+            | _p(
+                update_core_xy,
+                F.Word3.UPDATE_CORE_XY_OFFSET,
+                F.Word3.UPDATE_CORE_XY_MASK,
+            )
+            | _p(
+                update_core_x,
+                F.Word3.UPDATE_CORE_X_OFFSET,
+                F.Word3.UPDATE_CORE_X_MASK,
+            )
+            | _p(
+                update_core_y,
+                F.Word3.UPDATE_CORE_Y_OFFSET,
+                F.Word3.UPDATE_CORE_Y_MASK,
+            )
+            | _p(
+                test_core_xy,
+                F.Word3.TEST_CORE_XY_OFFSET,
+                F.Word3.TEST_CORE_XY_MASK,
+            )
+            | _p(
+                test_core_x,
+                F.Word3.TEST_CORE_X_OFFSET,
+                F.Word3.TEST_CORE_X_MASK,
+            )
+            | _p(
+                test_core_y_h1,
+                F.Word3.TEST_CORE_Y_HIGH1_OFFSET,
+                F.Word3.TEST_CORE_Y_HIGH1_MASK,
+            )
+        )
+        w4 = (
+            _p(
+                test_core_y_l5,
+                F.Word4.TEST_CORE_Y_LOW5_OFFSET,
+                F.Word4.TEST_CORE_Y_LOW5_MASK,
+            )
+            | _p(
+                core_reg["global_send"],
+                F.Word4.GLOBAL_SEND_OFFSET,
+                F.Word4.GLOBAL_SEND_MASK,
+            )
+            | _p(
+                core_reg["global_receive"],
+                F.Word4.GLOBAL_RECEIVE_OFFSET,
+                F.Word4.GLOBAL_RECEIVE_MASK,
+            )
+            | _p(
+                core_reg["thread_number"],
+                F.Word4.THREAD_NUMBER_OFFSET,
+                F.Word4.THREAD_NUMBER_MASK,
+            )
+            | _p(
+                core_reg["busy_cycle"],
+                F.Word4.BUSY_CYCLE_OFFSET,
+                F.Word4.BUSY_CYCLE_MASK,
+            )
+            | _p(
+                core_reg["delay_cycle"],
+                F.Word4.DELAY_CYCLE_OFFSET,
+                F.Word4.DELAY_CYCLE_MASK,
+            )
+            | _p(
+                core_reg["width_cycle"],
+                F.Word4.WIDTH_CYCLE_OFFSET,
+                F.Word4.WIDTH_CYCLE_MASK,
+            )
+        )
+        w5 = (
+            _p(
+                core_reg["tick_start"],
+                F.Word5.TICK_START_OFFSET,
+                F.Word5.TICK_START_MASK,
+            )
+            | _p(
+                core_reg["tick_duration"],
+                F.Word5.TICK_DURATION_OFFSET,
+                F.Word5.TICK_DURATION_MASK,
+            )
+            | _p(
+                core_reg["tick_initial"],
+                F.Word5.TICK_INITIAL_OFFSET,
+                F.Word5.TICK_INITIAL_MASK,
+            )
+        )
+
+        pkg = np.array([w1, w2, w3, w4, w5], dtype=FRAME_DTYPE)
+        return OnlineFrameGenV2.make_package(
+            FH.CONFIG_TYPE1, pkt_offset, pkt_ncopy, start_addr, pkg
+        )
+
+    @staticmethod
+    def gen_config_frame2(
+        pkt_offset: CoordZXYOffset,
+        potentials: ArrayLike,
+        activations: ArrayLike,
+        pkt_ncopy: AERPacketZXYCopy = AERPacketZXYCopy(),
+        start_addr: int = 0,
+    ) -> FrameArrayType:
+        F = On_Cfg2_V2
+        arr_pot_u64 = _array_to_bits(potentials, 32).astype(FRAME_DTYPE).ravel()
+        arr_act_u64 = _array_to_bf16_bits(activations).astype(FRAME_DTYPE).ravel()
+
+        if arr_pot_u64.size != arr_act_u64.size:
+            raise ValueError(
+                f"potentials and activations should have the same size, "
+                f"but got {arr_pot_u64.size} != {arr_act_u64.size}"
+            )
+
+        packages = (
+            _p(arr_pot_u64, F.POTENTIAL_OFFSET, F.POTENTIAL_MASK)
+            | _p(arr_act_u64, F.ACTIVATION_OFFSET, F.ACTIVATION_MASK)
+        ).astype(FRAME_DTYPE)
+        return OnlineFrameGenV2.make_package(
+            FH.CONFIG_TYPE2, pkt_offset, pkt_ncopy, start_addr, packages
+        )
+
+    @staticmethod
+    def gen_config_frame3_pkg_header(
+        pkt_offset: CoordZXYOffset,
+        start_addr: int,
+        n_package: int,
+        pkt_ncopy: AERPacketZXYCopy = AERPacketZXYCopy(),
+    ) -> FrameArrayType:
+        header = FramePackageHeaderV2.make_pkg_header(
+            FH.CONFIG_TYPE3,
+            pkt_offset,
+            pkt_ncopy,
+            start_addr,
+            FramePackageType.CONF_TESTOUT,
+            n_package,
+        )
+        return header.value
+
+    @staticmethod
+    def gen_config_frame3_pkg_neu(
+        dest_info: OnlineNeuDestInfoV2 | dict[str, Any],
+        full_attrs1: OnlineNeuFullAttrsV2Part1 | dict[str, Any] | None,
+        full_attrs2: OnlineNeuFullAttrsV2Part2 | dict[str, Any] | None,
+        folded_attrs1: OnlineNeuFoldedAttrsV2Part1 | dict[str, Any] | None,
+        folded_attrs2_: Sequence[OnlineNeuFoldedAttrsV2Part2 | dict[str, Any]],
+    ) -> tuple[FrameArrayType, FrameArrayType, FrameArrayType]:
+        dest_info_dump = OnlineNeuDestInfoV2.model_validate(
+            dest_info, strict=True
+        ).model_dump()
+        pkg_half_neu = np.array([], dtype=FRAME_DTYPE)
+        pkg_full_neu = np.array([], dtype=FRAME_DTYPE)
+        pkg_folded_neu = np.array([], dtype=FRAME_DTYPE)
+
+        if full_attrs1 is not None:
+            full_attrs1_dump = OnlineNeuFullAttrsV2Part1.model_validate(
+                full_attrs1, strict=True
+            ).model_dump()
+            pkg_half_neu = OnlineFrameGenV2._gen_pkg_half_neu(
+                dest_info_dump, full_attrs1_dump
+            )
+
+            if full_attrs2 is not None:
+                full_attrs2_dump = OnlineNeuFullAttrsV2Part2.model_validate(
+                    full_attrs2, strict=True
+                ).model_dump()
+                pkg_full_neu = OnlineFrameGenV2._gen_pkg_full_neu(
+                    dest_info_dump, full_attrs1_dump, full_attrs2_dump
+                )
+        elif full_attrs2 is not None:
+            raise ValueError("attributes of full neuron are incomplete, missing part1")
+
+        if folded_attrs1 is not None:
+            if len(folded_attrs2_) == 0:
+                raise ValueError(
+                    "attributes of folded neuron are incomplete, missing part2"
+                )
+
+            folded_attrs1_dump = OnlineNeuFoldedAttrsV2Part1.model_validate(
+                folded_attrs1, strict=True
+            ).model_dump()
+            folded_attrs2_dump = [
+                OnlineNeuFoldedAttrsV2Part2.model_validate(
+                    attrs2, strict=True
+                ).model_dump()
+                for attrs2 in folded_attrs2_
+            ]
+            pkg_folded_neu = OnlineFrameGenV2._gen_pkg_folded_neu(
+                folded_attrs1_dump, *folded_attrs2_dump
+            )
+        elif len(folded_attrs2_) > 0:
+            raise ValueError(
+                "attributes of folded neuron are incomplete, missing part1"
+            )
+
+        return pkg_half_neu, pkg_full_neu, pkg_folded_neu
+
+    @staticmethod
+    def gen_config_frame3_pkg_half(
+        dest_info: OnlineNeuDestInfoV2 | dict[str, Any],
+        half_attrs: OnlineNeuHalfAttrsV2 | dict[str, Any],
+    ) -> FrameArrayType:
+        pkg_half_neu, _, _ = OnlineFrameGenV2.gen_config_frame3_pkg_neu(
+            dest_info, half_attrs, None, None, []
+        )
+        return pkg_half_neu
+
+    @staticmethod
+    def gen_config_frame3_pkg_full(
+        dest_info: OnlineNeuDestInfoV2 | dict[str, Any],
+        full_attrs1: OnlineNeuFullAttrsV2Part1 | dict[str, Any],
+        full_attrs2: OnlineNeuFullAttrsV2Part2 | dict[str, Any],
+    ) -> FrameArrayType:
+        _, pkg_full_neu, _ = OnlineFrameGenV2.gen_config_frame3_pkg_neu(
+            dest_info, full_attrs1, full_attrs2, None, []
+        )
+        return pkg_full_neu
+
+    @staticmethod
+    def gen_config_frame3_pkg_folded(
+        folded_attrs1: OnlineNeuFoldedAttrsV2Part1 | dict[str, Any],
+        folded_attrs2_: Sequence[OnlineNeuFoldedAttrsV2Part2 | dict[str, Any]],
+    ) -> FrameArrayType:
+        if len(folded_attrs2_) == 0:
+            raise ValueError("attributes of folded neuron are incomplete")
+
+        folded_attrs1_dump = OnlineNeuFoldedAttrsV2Part1.model_validate(
+            folded_attrs1, strict=True
+        ).model_dump()
+        folded_attrs2_dump = [
+            OnlineNeuFoldedAttrsV2Part2.model_validate(attrs2, strict=True).model_dump()
+            for attrs2 in folded_attrs2_
+        ]
+        return OnlineFrameGenV2._gen_pkg_folded_neu(
+            folded_attrs1_dump, *folded_attrs2_dump
+        )
+
+    @staticmethod
+    def _gen_pkg_half_neu(
+        dest_info: dict[str, Any], half_attrs: dict[str, Any]
+    ) -> FrameArrayType:
+        F = On_Cfg3_V2.Full
+        weight_skew_h12, weight_skew_l4 = bin_split(
+            int(half_attrs["weight_skew"]), 4, 12
+        )
+        addr_core_xy, addr_core_x, addr_core_y = coordzxy_to_sign_magnitude(
+            (
+                int(dest_info["addr_core_xy"]),
+                int(dest_info["addr_core_x"]),
+                int(dest_info["addr_core_y"]),
+            )
+        )
+        addr_copy_xy, addr_copy_x, addr_copy_y = coordzxy_to_sign_magnitude(
+            (
+                int(dest_info["addr_copy_xy"]),
+                int(dest_info["addr_copy_x"]),
+                int(dest_info["addr_copy_y"]),
+            )
+        )
+        # Online config frame type III is packed from RAM[n][63:0] to RAM[n][127:64].
+        w1 = (
+            _p(
+                weight_skew_l4,
+                F.Word1.WEIGHT_SKEW_LOW4_OFFSET,
+                F.Word1.WEIGHT_SKEW_LOW4_MASK,
+            )
+            | _p(
+                half_attrs["weight_address_start"],
+                F.Word1.WEIGHT_ADDRESS_START_OFFSET,
+                F.Word1.WEIGHT_ADDRESS_START_MASK,
+            )
+            | _p(
+                half_attrs["weight_address_end"],
+                F.Word1.WEIGHT_ADDRESS_END_OFFSET,
+                F.Word1.WEIGHT_ADDRESS_END_MASK,
+            )
+            | _p(
+                half_attrs["output_type"],
+                F.Word1.OUTPUT_TYPE_OFFSET,
+                F.Word1.OUTPUT_TYPE_MASK,
+            )
+            | _p(
+                half_attrs["fold_type"],
+                F.Word1.FOLD_TYPE_OFFSET,
+                F.Word1.FOLD_TYPE_MASK,
+            )
+            | _p(
+                half_attrs["neuron_type"],
+                F.Word1.NEURON_TYPE_OFFSET,
+                F.Word1.NEURON_TYPE_MASK,
+            )
+            | _p(
+                _value_to_bits(half_attrs["vjt"], 32),
+                F.Word1.VJT_OFFSET,
+                F.Word1.VJT_MASK,
+            )
+        )
+        w2 = (
+            _p(
+                dest_info["tick_relative"],
+                F.Word2.TICK_RELATIVE_OFFSET,
+                F.Word2.TICK_RELATIVE_MASK,
+            )
+            | _p(
+                dest_info["addr_axon"],
+                F.Word2.ADDR_AXON_OFFSET,
+                F.Word2.ADDR_AXON_MASK,
+            )
+            | _p(
+                addr_core_xy,
+                F.Word2.ADDR_CORE_XY_OFFSET,
+                F.Word2.ADDR_CORE_XY_MASK,
+            )
+            | _p(
+                addr_core_x,
+                F.Word2.ADDR_CORE_X_OFFSET,
+                F.Word2.ADDR_CORE_X_MASK,
+            )
+            | _p(
+                addr_core_y,
+                F.Word2.ADDR_CORE_Y_OFFSET,
+                F.Word2.ADDR_CORE_Y_MASK,
+            )
+            | _p(
+                addr_copy_xy,
+                F.Word2.ADDR_COPY_XY_OFFSET,
+                F.Word2.ADDR_COPY_XY_MASK,
+            )
+            | _p(
+                addr_copy_x,
+                F.Word2.ADDR_COPY_X_OFFSET,
+                F.Word2.ADDR_COPY_X_MASK,
+            )
+            | _p(
+                addr_copy_y,
+                F.Word2.ADDR_COPY_Y_OFFSET,
+                F.Word2.ADDR_COPY_Y_MASK,
+            )
+            | _p(
+                weight_skew_h12,
+                F.Word2.WEIGHT_SKEW_HIGH12_OFFSET,
+                F.Word2.WEIGHT_SKEW_HIGH12_MASK,
+            )
+        )
+        return np.array([w1, w2], dtype=FRAME_DTYPE)
+
+    @staticmethod
+    def _gen_pkg_full_neu(
+        dest_info: dict[str, Any],
+        full_attrs1: dict[str, Any],
+        full_attrs2: dict[str, Any],
+    ) -> FrameArrayType:
+        F = On_Cfg3_V2.Full
+        pkg_half_neu = OnlineFrameGenV2._gen_pkg_half_neu(dest_info, full_attrs1)
+        threshold_pos_h12, threshold_pos_l20 = bin_split(
+            _value_to_bits(full_attrs2["threshold_pos"], 32), 20, 12
+        )
+        # Continue the same little-endian RAM word order: low 64 bits first, then high 64 bits.
+        w3 = (
+            _p(
+                threshold_pos_l20,
+                F.Word3.THRESHOLD_POS_LOW20_OFFSET,
+                F.Word3.THRESHOLD_POS_LOW20_MASK,
+            )
+            | _p(
+                full_attrs2["lateral_inhibition"],
+                F.Word3.LATERAL_INHIBITION_OFFSET,
+                F.Word3.LATERAL_INHIBITION_MASK,
+            )
+            | _p(
+                full_attrs2["leak_multi_sequence"],
+                F.Word3.LEAK_MULTI_SEQUENCE_OFFSET,
+                F.Word3.LEAK_MULTI_SEQUENCE_MASK,
+            )
+            | _p(
+                full_attrs2["leak_multi_input"],
+                F.Word3.LEAK_MULTI_INPUT_OFFSET,
+                F.Word3.LEAK_MULTI_INPUT_MASK,
+            )
+            | _p(
+                full_attrs2["leak_multi_mode"],
+                F.Word3.LEAK_MULTI_MODE_OFFSET,
+                F.Word3.LEAK_MULTI_MODE_MASK,
+            )
+            | _p(
+                full_attrs2["leak_add_mode"],
+                F.Word3.LEAK_ADD_MODE_OFFSET,
+                F.Word3.LEAK_ADD_MODE_MASK,
+            )
+            | _p(
+                full_attrs2["leak_tau"],
+                F.Word3.LEAK_TAU_OFFSET,
+                F.Word3.LEAK_TAU_MASK,
+            )
+            | _p(
+                _value_to_bf16_bits(full_attrs2["vjt_initial"]),
+                F.Word3.VJT_INITIAL_OFFSET,
+                F.Word3.VJT_INITIAL_MASK,
+            )
+            | _p(
+                full_attrs2["weight_compress"],
+                F.Word3.WEIGHT_COMPRESS_OFFSET,
+                F.Word3.WEIGHT_COMPRESS_MASK,
+            )
+            | _p(
+                _value_to_bf16_bits(full_attrs2["leak_v"]),
+                F.Word3.LEAK_V_OFFSET,
+                F.Word3.LEAK_V_MASK,
+            )
+        )
+        w4 = (
+            _p(
+                getattr(full_attrs2["reset_mode"], "value", full_attrs2["reset_mode"]),
+                F.Word4.RESET_MODE_OFFSET,
+                F.Word4.RESET_MODE_MASK,
+            )
+            | _p(
+                _value_to_bf16_bits(full_attrs2["reset_v"]),
+                F.Word4.RESET_V_OFFSET,
+                F.Word4.RESET_V_MASK,
+            )
+            | _p(
+                full_attrs2["threshold_neg_mode"],
+                F.Word4.THRESHOLD_NEG_MODE_OFFSET,
+                F.Word4.THRESHOLD_NEG_MODE_MASK,
+            )
+            | _p(
+                full_attrs2["threshold_pos_mode"],
+                F.Word4.THRESHOLD_POS_MODE_OFFSET,
+                F.Word4.THRESHOLD_POS_MODE_MASK,
+            )
+            | _p(
+                _value_to_bits(full_attrs2["threshold_neg"], 32),
+                F.Word4.THRESHOLD_NEG_OFFSET,
+                F.Word4.THRESHOLD_NEG_MASK,
+            )
+            | _p(
+                threshold_pos_h12,
+                F.Word4.THRESHOLD_POS_HIGH12_OFFSET,
+                F.Word4.THRESHOLD_POS_HIGH12_MASK,
+            )
+        )
+        return np.r_[pkg_half_neu, w3, w4].astype(FRAME_DTYPE)
+
+    @staticmethod
+    def _gen_pkg_folded_neu(
+        folded_attrs1: dict[str, Any], *folded_attrs2: dict[str, Any]
+    ) -> FrameArrayType:
+        F = On_Cfg3_V2.Fold
+        fold_skew_y_h9, fold_skew_y_l2 = bin_split(
+            int(folded_attrs1["fold_skew_y"]), 2, 9
+        )
+        w1 = (
+            _p(
+                fold_skew_y_l2,
+                F.Word1.FOLD_SKEW_Y_LOW2_OFFSET,
+                F.Word1.FOLD_SKEW_Y_LOW2_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_axon_xy"],
+                F.Word1.FOLD_AXON_XY_OFFSET,
+                F.Word1.FOLD_AXON_XY_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_axon_x"],
+                F.Word1.FOLD_AXON_X_OFFSET,
+                F.Word1.FOLD_AXON_X_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_axon_y"],
+                F.Word1.FOLD_AXON_Y_OFFSET,
+                F.Word1.FOLD_AXON_Y_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_number"],
+                F.Word1.FOLD_NUMBER_OFFSET,
+                F.Word1.FOLD_NUMBER_MASK,
+            )
+        )
+        w2 = (
+            _p(
+                folded_attrs1["fold_range_xy"],
+                F.Word2.FOLD_RANGE_XY_OFFSET,
+                F.Word2.FOLD_RANGE_XY_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_range_x"],
+                F.Word2.FOLD_RANGE_X_OFFSET,
+                F.Word2.FOLD_RANGE_X_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_range_y"],
+                F.Word2.FOLD_RANGE_Y_OFFSET,
+                F.Word2.FOLD_RANGE_Y_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_skew_xy"],
+                F.Word2.FOLD_SKEW_XY_OFFSET,
+                F.Word2.FOLD_SKEW_XY_MASK,
+            )
+            | _p(
+                folded_attrs1["fold_skew_x"],
+                F.Word2.FOLD_SKEW_X_OFFSET,
+                F.Word2.FOLD_SKEW_X_MASK,
+            )
+            | _p(
+                fold_skew_y_h9,
+                F.Word2.FOLD_SKEW_Y_HIGH9_OFFSET,
+                F.Word2.FOLD_SKEW_Y_HIGH9_MASK,
+            )
+        )
+
+        if len(folded_attrs2) == 0:
+            raise ValueError("at least one folded neuron attrs part2 is required")
+
+        v0 = _array_to_bits([item["fold_vjt_0"] for item in folded_attrs2], 32).astype(
+            FRAME_DTYPE
+        )
+        v1 = _array_to_bits([item["fold_vjt_1"] for item in folded_attrs2], 32).astype(
+            FRAME_DTYPE
+        )
+        v2 = _array_to_bits([item["fold_vjt_2"] for item in folded_attrs2], 32).astype(
+            FRAME_DTYPE
+        )
+        v3 = _array_to_bits([item["fold_vjt_3"] for item in folded_attrs2], 32).astype(
+            FRAME_DTYPE
+        )
+
+        # Each folded entry is emitted as RAM[n][63:0], RAM[n][127:64].
+        w3 = (
+            _p(v1, F.Word3.FOLD_VJT_1_OFFSET, F.Word3.FOLD_VJT_1_MASK)
+            | _p(v0, F.Word3.FOLD_VJT_0_OFFSET, F.Word3.FOLD_VJT_0_MASK)
+        ).astype(FRAME_DTYPE)
+        w4 = (
+            _p(v3, F.Word4.FOLD_VJT_3_OFFSET, F.Word4.FOLD_VJT_3_MASK)
+            | _p(v2, F.Word4.FOLD_VJT_2_OFFSET, F.Word4.FOLD_VJT_2_MASK)
+        ).astype(FRAME_DTYPE)
+
+        v = np.zeros(len(w3) * 2, dtype=FRAME_DTYPE)
+        v[0::2] = w3
+        v[1::2] = w4
+
+        return np.r_[w1, w2, v].astype(FRAME_DTYPE)
+
+    @staticmethod
+    def gen_config_frame3_weight_pkg(
+        weight: ArrayLike,
+        csc_compress: bool | CSCAccelerateMode = False,
+    ) -> FrameArrayType:
+        weight_arr = np.asarray(weight)
+        if weight_arr.ndim != 1:
+            raise ValueError(
+                f"'weight' must be a 1D array, but got ndim={weight_arr.ndim}."
+            )
+
+        if csc_compress != CSCAccelerateMode.DISABLE:
+            return weight_csc_u16_pack(weight_arr)
+
+        return weight_dense_u16_pack(weight_arr)
+
+    @staticmethod
+    def gen_config_frame4(
+        pkt_offset: CoordZXYOffset,
+        input_array: ArrayLike,
+        pkt_ncopy: AERPacketZXYCopy = AERPacketZXYCopy(),
+        start_addr: int = 0,
+    ) -> FrameArrayType:
+        packages = np.asarray(input_array, dtype=FRAME_DTYPE).ravel()
+        return OnlineFrameGenV2.make_package(
+            FH.CONFIG_TYPE4, pkt_offset, pkt_ncopy, start_addr, packages
+        )
+
+    @staticmethod
+    def _gen_work_frame(
+        header: FH,
+        F: (
+            type[On_Work1_V2]
+            | type[On_Work2_V2]
+            | type[On_Work3_V2]
+            | type[On_Work4_V2]
+        ),
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        timesteps: ArrayLike,
+        axons: ArrayLike,
+        target_lcn: int | LCN_EX,
+        data: ArrayLike,
+    ) -> FrameArrayType:
+        data_parts = _normalize_online_work_data(data)
+        ts = np.asarray(timesteps, dtype=FRAME_DTYPE).ravel()
+        ax = np.asarray(axons, dtype=FRAME_DTYPE).ravel()
+
+        if ax.size != ts.size:
+            raise ValueError(
+                f"the size of axons & timeslots are not equal, {ax.size} != {ts.size}."
+            )
+        if data_parts.shape[0] != ts.size:
+            raise ValueError(
+                f"the size of data & timeslots are not equal, {data_parts.shape[0]} != {ts.size}."
+            )
+
+        ts_width, ax_width = OnlineFrameGenV2.LCN_TO_TS_AXON_WIDTHS[
+            _normalize_online_lcn(target_lcn)
+        ]
+        ts_ax_addr = _p(
+            ((ts & _mask(ts_width)) << ax_width) | (ax & _mask(ax_width)),
+            F.TIMESTEP_AXON_OFFSET,
+            F.TIMESTEP_AXON_MASK,
+        )
+
+        mask = np.flatnonzero(np.any(data_parts != 0, axis=1))
+        if mask.size == 0:
+            return np.array([], dtype=FRAME_DTYPE)
+
+        frame_dest = get_frame_dest_v2(header, pkt_offset, pkt_ncopy)
+        data_u8 = data_parts[mask].reshape(-1).astype(FRAME_DTYPE)
+        ts_ax_addr = np.repeat(ts_ax_addr[mask], data_parts.shape[1])
+        return (frame_dest + ts_ax_addr + data_u8).astype(FRAME_DTYPE)
+
+    @staticmethod
+    def gen_work_frame1(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        timesteps: ArrayLike,
+        axons: ArrayLike,
+        target_lcn: int | LCN_EX,
+        data: ArrayLike,
+    ) -> FrameArrayType:
+        return OnlineFrameGenV2._gen_work_frame(
+            FH.WORK_TYPE1,
+            On_Work1_V2,
+            pkt_offset,
+            pkt_ncopy,
+            timesteps,
+            axons,
+            target_lcn,
+            data,
+        )
+
+    @staticmethod
+    def gen_work_frame2(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        timesteps: ArrayLike,
+        axons: ArrayLike,
+        target_lcn: int | LCN_EX,
+        data: ArrayLike,
+    ) -> FrameArrayType:
+        return OnlineFrameGenV2._gen_work_frame(
+            FH.WORK_TYPE2,
+            On_Work2_V2,
+            pkt_offset,
+            pkt_ncopy,
+            timesteps,
+            axons,
+            target_lcn,
+            data,
+        )
+
+    @staticmethod
+    def gen_work_frame3(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        timesteps: ArrayLike,
+        axons: ArrayLike,
+        target_lcn: int | LCN_EX,
+        data: ArrayLike,
+    ) -> FrameArrayType:
+        return OnlineFrameGenV2._gen_work_frame(
+            FH.WORK_TYPE3,
+            On_Work3_V2,
+            pkt_offset,
+            pkt_ncopy,
+            timesteps,
+            axons,
+            target_lcn,
+            data,
+        )
+
+    @staticmethod
+    def gen_work_frame4(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        timesteps: ArrayLike,
+        axons: ArrayLike,
+        target_lcn: int | LCN_EX,
+        data: ArrayLike,
+    ) -> FrameArrayType:
+        return OnlineFrameGenV2._gen_work_frame(
+            FH.WORK_TYPE4,
+            On_Work4_V2,
+            pkt_offset,
+            pkt_ncopy,
+            timesteps,
+            axons,
+            target_lcn,
+            data,
+        )
+
+    @staticmethod
+    def gen_control_frame1(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        n_timestep: int,
+    ) -> FrameArrayType:
+        F = On_Ctrl1_V2
+        if n_timestep > F.NUM_TIMESTEP_MASK:
+            raise ValueError(f"'overflow' out of range {F.NUM_TIMESTEP_MASK}")
+
+        return FrameV2(FH.CTRL_TYPE1, pkt_offset, pkt_ncopy, n_timestep).value
+
+    @staticmethod
+    def gen_control_frame2(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+    ) -> FrameArrayType:
+        return FrameV2(FH.CTRL_TYPE2, pkt_offset, pkt_ncopy, 0).value
+
+    @staticmethod
+    def gen_complete_frame(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        thread_id: int = 0,
+    ) -> FrameArrayType:
+        F = On_Ctrl3_V2
+        if thread_id > F.THREAD_ID_MASK:
+            raise ValueError(f"'thread_id' out of range {F.THREAD_ID_MASK})")
+
+        return FrameV2(FH.CTRL_TYPE3, pkt_offset, pkt_ncopy, thread_id).value
+
+    @staticmethod
+    def gen_update_frame(
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        ext_multicast_addr: int,
+    ) -> FrameArrayType:
+        F = On_Ctrl4_V2
+        if ext_multicast_addr > F.EXT_MULTICAST_ADDR_MASK:
+            raise ValueError(
+                f"'ext_multicast_addr' out of range {F.EXT_MULTICAST_ADDR_MASK}"
+            )
+
+        return FrameV2(FH.CTRL_TYPE4, pkt_offset, pkt_ncopy, ext_multicast_addr).value
+
+    gen_control_frame3 = gen_complete_frame
+    gen_control_frame4 = gen_update_frame
+
+
 # class OfflineFrameDecoderV2:
 #     @staticmethod
 #     def decode_voltage(frame: FrameArrayType, target_lcn: LCN_EX) -> FrameArrayType:
 #         pass
+
+
+def weight_dense_u16_pack(weight: np.ndarray) -> FrameArrayType:
+    """Array 16-bit dense weights in RAM."""
+
+    weight_u64 = _array_to_bf16_bits(weight).astype(FRAME_DTYPE).ravel()
+    align_size = 8
+    aligned_size = math.ceil(weight_u64.size / align_size) * align_size
+    if (pad := aligned_size - weight_u64.size) > 0:
+        weight_u64 = np.pad(weight_u64, (0, pad), constant_values=0)
+
+    if weight_u64.size == 0:
+        return np.array([], dtype=FRAME_DTYPE)
+
+    weight_u64 = weight_u64.reshape(-1, align_size)
+    shifts = 16 * np.arange(4, dtype=np.uint8)
+    result = np.zeros((weight_u64.shape[0] * 2,), dtype=FRAME_DTYPE)
+    result[0::2] = np.bitwise_or.reduce(
+        weight_u64[:, :4] << shifts, axis=1, dtype=FRAME_DTYPE
+    )
+    result[1::2] = np.bitwise_or.reduce(
+        weight_u64[:, 4:] << shifts, axis=1, dtype=FRAME_DTYPE
+    )
+    return result
+
+
+def weight_csc_u16_pack(weight: np.ndarray) -> FrameArrayType:
+    """Array 16-bit CSC weights in RAM."""
+
+    weight_arr = np.asarray(weight).ravel()
+    row_indices = np.flatnonzero(weight_arr != 0)
+    if row_indices.size == 0:
+        return np.array([], dtype=FRAME_DTYPE)
+
+    weight_u64 = _array_to_bf16_bits(weight_arr).astype(FRAME_DTYPE).ravel()
+    w_nonzero = weight_u64[row_indices]
+    n_nonzero_w_per_addr = 4
+    n_chunk = math.ceil(row_indices.size / n_nonzero_w_per_addr)
+
+    if (pad := n_chunk * n_nonzero_w_per_addr - row_indices.size) > 0:
+        if row_indices.size == weight_arr.size:
+            raise ValueError(
+                "the sparse weight cannot be aligned in groups of 4 "
+                + "because there are all non-zero values."
+            )
+
+        idx_first_zero = np.where(weight_arr == 0)[0][0]
+        w_nonzero = np.pad(w_nonzero, (0, pad), constant_values=0)
+        row_indices = np.pad(row_indices, (0, pad), constant_values=idx_first_zero)
+
+    w_chunks = w_nonzero.reshape(n_chunk, n_nonzero_w_per_addr)
+    idx_chunks = row_indices.reshape(n_chunk, n_nonzero_w_per_addr).astype(FRAME_DTYPE)
+    shifts = 16 * np.arange(n_nonzero_w_per_addr, dtype=np.uint8)
+
+    result = np.zeros((2 * n_chunk,), dtype=FRAME_DTYPE)
+    result[0::2] = np.bitwise_or.reduce(w_chunks << shifts, axis=1, dtype=FRAME_DTYPE)
+    result[1::2] = np.bitwise_or.reduce(idx_chunks << shifts, axis=1, dtype=FRAME_DTYPE)
+    return result
 
 
 def weight_dense_pack(weight: np.ndarray, weight_width: DataWidthLE8) -> FrameArrayType:

--- a/paicorelib/neuron_defs_v2.py
+++ b/paicorelib/neuron_defs_v2.py
@@ -5,6 +5,7 @@ from .utils import _mask
 __all__ = [
     # Neuron reg limits
     "OfflineNeuRegLimV2",
+    "OnlineNeuRegLimV2",
     # Types
     "OutputType",
     "FoldType",
@@ -45,6 +46,13 @@ class OfflineNeuRegLimV2:
     FOLD_SKEW_MAX = _mask(11)
     FOLD_AXON_MAX = _mask(11)
     FOLD_NUMBER_MAX = _mask(29)
+
+
+class OnlineNeuRegLimV2(OfflineNeuRegLimV2):
+    """Limits of online neuron registers for chip v2.5."""
+
+    ADDR_AXON_MAX = _mask(8)
+    OUTPUT_TYPE_MAX = _mask(2)
 
 
 @unique

--- a/paicorelib/neuron_model_v2.py
+++ b/paicorelib/neuron_model_v2.py
@@ -19,6 +19,7 @@ from .neuron_defs_v2 import (
     LeakMultiMode,
     NeuronType,
     OfflineNeuRegLimV2,
+    OnlineNeuRegLimV2,
     OutputType,
     ThresholdNegMode,
     ThresholdPosMode,
@@ -33,6 +34,10 @@ __all__ = [
     "OfflineNeuFullAttrsV2Part1",
     "OfflineNeuFullAttrsV2Part2",
     "OfflineNeuHalfAttrsV2",
+    "OnlineNeuDestInfoV2",
+    "OnlineNeuHalfAttrsV2",
+    "OnlineNeuFullAttrsV2Part1",
+    "OnlineNeuFullAttrsV2Part2",
     "OfflineNeuFoldedAttrsV2Part1",
     "OfflineNeuFoldedAttrsV2Part2",
     "OnlineNeuFoldedAttrsV2Part1",
@@ -150,6 +155,30 @@ OfflineNeuHalfAttrsV2 = OfflineNeuCommonAttrsV2
 OfflineNeuFullAttrsV2Part1 = OfflineNeuHalfAttrsV2
 
 
+class OnlineNeuDestInfoV2(NeuDestInfoV2):
+    addr_axon: Annotated[
+        NonNegativeInt,
+        Field(le=OnlineNeuRegLimV2.ADDR_AXON_MAX, description="Target axon address."),
+    ]
+
+
+class OnlineNeuCommonAttrsV2(NeuCommonAttrsV2):
+    output_type: Annotated[
+        NonNegativeInt,
+        Field(
+            le=OnlineNeuRegLimV2.OUTPUT_TYPE_MAX,
+            description="Output type selection.",
+        ),
+    ]
+    vjt: Annotated[
+        float, Field(default=0.0, description="Current time step membrane potential.")
+    ] = 0.0
+
+
+OnlineNeuHalfAttrsV2 = OnlineNeuCommonAttrsV2
+OnlineNeuFullAttrsV2Part1 = OnlineNeuHalfAttrsV2
+
+
 class OfflineNeuFullAttrsV2Part2(NeuAttrs):
     reset_mode: Annotated[ResetMode, Field(description="Reset mode selection.")]
     reset_v: Annotated[
@@ -226,6 +255,60 @@ class OfflineNeuFullAttrsV2Part2(NeuAttrs):
 
 class OfflineNeuFullAttrsV2(OfflineNeuFullAttrsV2Part1, OfflineNeuFullAttrsV2Part2):
     pass
+
+
+class OnlineNeuFullAttrsV2Part2(NeuAttrs):
+    reset_mode: Annotated[ResetMode, Field(description="Reset mode selection.")]
+    reset_v: Annotated[float, Field(description="Membrane potential reset value.")]
+
+    threshold_neg_mode: Annotated[
+        ThresholdNegMode, Field(description="Negative threshold mode selection.")
+    ]
+    threshold_pos_mode: Annotated[
+        ThresholdPosMode, Field(description="Positive threshold mode selection.")
+    ]
+
+    threshold_neg: Annotated[float, Field(description="Negative threshold.")]
+    threshold_pos: Annotated[float, Field(description="Positive threshold.")]
+
+    lateral_inhibition: Annotated[
+        LateralInhibitionMode, Field(description="Lateral inhibition mode selection.")
+    ]
+    leak_multi_sequence: Annotated[
+        LeakMultiComparisonOrder, Field(description="Multiplicative leak sequence.")
+    ]
+    leak_multi_input: Annotated[
+        LeakMultiInputMode,
+        Field(description="Whether input participates in multiplicative leak."),
+    ]
+    leak_multi_mode: Annotated[
+        LeakMultiMode, Field(description="Multiplicative leak mode selection.")
+    ]
+    leak_add_mode: Annotated[
+        LeakAddMode, Field(description="Additive leak mode selection.")
+    ]
+
+    leak_tau: Annotated[
+        int,
+        Field(
+            ge=OfflineNeuRegLimV2.LEAK_TAU_MIN,
+            le=OfflineNeuRegLimV2.LEAK_TAU_MAX,
+            description="Multiplicative leak shift amount.",
+        ),
+    ]
+    leak_v: Annotated[float, Field(description="Additive leak potential.")]
+
+    weight_compress: Annotated[
+        WeightCompressType,
+        Field(
+            default=WeightCompressType.DENSE,
+            description="Weight compression type (Dense/Sparse).",
+        ),
+    ]
+    vjt_initial: Annotated[
+        float,
+        Field(default=0.0, description="Initial membrane potential."),
+    ] = 0.0
 
 
 class NeuFoldedAttrsV2Part1(NeuAttrs):
@@ -358,5 +441,10 @@ class OfflineNeuHalfConfV2(BaseModel):
 OfflineNeuDestInfoV2Checker = TypeAdapter(OfflineNeuDestInfoV2)
 OfflineNeuHalfAttrsV2Checker = TypeAdapter(OfflineNeuHalfAttrsV2)
 OfflineNeuFullAttrsV2Part2Checker = TypeAdapter(OfflineNeuFullAttrsV2Part2)
+OnlineNeuDestInfoV2Checker = TypeAdapter(OnlineNeuDestInfoV2)
+OnlineNeuHalfAttrsV2Checker = TypeAdapter(OnlineNeuHalfAttrsV2)
+OnlineNeuFullAttrsV2Part2Checker = TypeAdapter(OnlineNeuFullAttrsV2Part2)
 OfflineNeuFoldedAttrsV2Part1Checker = TypeAdapter(OfflineNeuFoldedAttrsV2Part1)
 OfflineNeuFoldedAttrsV2Part2Checker = TypeAdapter(OfflineNeuFoldedAttrsV2Part2)
+OnlineNeuFoldedAttrsV2Part1Checker = TypeAdapter(OnlineNeuFoldedAttrsV2Part1)
+OnlineNeuFoldedAttrsV2Part2Checker = TypeAdapter(OnlineNeuFoldedAttrsV2Part2)

--- a/tests/framelib/test_frame_gen_v2.py
+++ b/tests/framelib/test_frame_gen_v2.py
@@ -5,6 +5,7 @@ from typing import Literal, cast
 import numpy as np
 import pytest
 
+from paicorelib.coordinate import coordzxy_to_sign_magnitude
 from paicorelib.core_defs import LCN_EX
 from paicorelib.core_defs_v2 import CSCAccelerateMode, DataSign, DataWidth
 from paicorelib.core_model_v2 import OfflineCoreRegV2
@@ -29,13 +30,23 @@ from paicorelib.framelib.frame_defs import (
 from paicorelib.framelib.frame_defs import (
     OfflineWorkFrame1FormatV2 as Off_Work1_V2,
 )
+from paicorelib.framelib.frame_defs import OnlineConfigFrame1FormatV2 as On_Cfg1_V2
+from paicorelib.framelib.frame_defs import OnlineConfigFrame2FormatV2 as On_Cfg2_V2
+from paicorelib.framelib.frame_defs import OnlineConfigFrame3FormatV2 as On_Cfg3_V2
+from paicorelib.framelib.frame_defs import OnlineControlFrame1FormatV2 as On_Ctrl1_V2
+from paicorelib.framelib.frame_defs import OnlineControlFrame3FormatV2 as On_Ctrl3_V2
+from paicorelib.framelib.frame_defs import OnlineControlFrame4FormatV2 as On_Ctrl4_V2
+from paicorelib.framelib.frame_defs import OnlineWorkFrame1FormatV2 as On_Work1_V2
 from paicorelib.framelib.frame_gen_v2 import (
     DataWidthLE8Like,
     FrameGenV2,
     OfflineFrameGenV2,
+    OnlineFrameGenV2,
     weight_csc_pack,
+    weight_csc_u16_pack,
     weight_csc_unpack,
     weight_dense_pack,
+    weight_dense_u16_pack,
     weight_dense_unpack,
 )
 from paicorelib.framelib.types import (
@@ -64,6 +75,8 @@ from paicorelib.neuron_model_v2 import (
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
+    OnlineNeuFoldedAttrsV2Part1,
+    OnlineNeuFoldedAttrsV2Part2,
 )
 from paicorelib.utils import _mask
 from tests.utils import (
@@ -109,6 +122,91 @@ def extract_lut_from_cf2(cf2: FrameArrayType, act_dtype: LUT_ACTIVATION_DTYPE):
         (lut >> Off_Cfg2_V2.ACTIVATION_OFFSET) & Off_Cfg2_V2.ACTIVATION_MASK
     ).astype(act_dtype)
     return arr_pot, arr_act
+
+
+def extract_online_lut_from_cf2(cf2: FrameArrayType):
+    assert cf2.size == 257
+    assert single_frame_header_check(cf2[0], FH.CONFIG_TYPE2)
+
+    lut = cf2[1:]
+    arr_pot = (
+        ((lut >> On_Cfg2_V2.POTENTIAL_OFFSET) & On_Cfg2_V2.POTENTIAL_MASK)
+        .astype(np.uint32)
+        .view(np.int32)
+    )
+    arr_act_bits = (
+        (lut >> On_Cfg2_V2.ACTIVATION_OFFSET) & On_Cfg2_V2.ACTIVATION_MASK
+    ).astype(np.uint16)
+    return arr_pot, arr_act_bits
+
+
+def scalar_bits(value, dtype) -> int:
+    arr = np.asarray([value], dtype=dtype)
+    view_dtype = {2: np.uint16, 4: np.uint32, 8: np.uint64}[arr.dtype.itemsize]
+    return int(arr.view(view_dtype)[0])
+
+
+def scalar_bf16_bits(value) -> int:
+    arr = np.asarray([value], dtype=np.dtype(np.float32).newbyteorder("<"))
+    bits = np.ascontiguousarray(arr).view(np.dtype(np.uint32).newbyteorder("<"))
+    return int(bits[0] >> 16)
+
+
+def array_bf16_bits(values) -> np.ndarray:
+    arr = np.asarray(values, dtype=np.dtype(np.float32).newbyteorder("<"))
+    bits = np.ascontiguousarray(arr).view(np.dtype(np.uint32).newbyteorder("<"))
+    return (bits >> 16).astype(np.uint16)
+
+
+def bf16_bits_to_float32(bits: np.ndarray) -> np.ndarray:
+    arr_u32 = np.asarray(bits, dtype=np.uint16).astype(np.uint32) << 16
+    return arr_u32.view(np.float32)
+
+
+def build_online_v2_core_reg_params(**overrides):
+    base = {
+        "snn_ann": 1,
+        "max_pooling": 0,
+        "add_potential": 1,
+        "zero_output": 0,
+        "work_mode": 5,
+        "input_core": 1,
+        "input_width": 2,
+        "output_core": 1,
+        "output_width": 3,
+        "LCN_AT": 1,
+        "LCN_MP": 2,
+        "LCN_LG": 3,
+        "target_LCN_AT": 4,
+        "target_LCN_MP": 5,
+        "target_LCN_LG": 6,
+        "axon_skew": 0x1234,
+        "neuron_number": 0x1456,
+        "update_number": 0x1555,
+        "csc_accelerate": CSCAccelerateMode.ENABLE,
+        "scale_in": np.float32(1.5),
+        "bias_in": np.float32(-2.0),
+        "scale_out": np.float32(0.25),
+        "bias_out": np.float32(-0.5),
+        "learning_rate": np.float32(3.0),
+        "update_core_xy": -1,
+        "update_core_x": 2,
+        "update_core_y": -3,
+        "test_core_xy": 4,
+        "test_core_x": -5,
+        "test_core_y": -6,
+        "global_send": 0x55,
+        "global_receive": 0x2A,
+        "thread_number": 0x155,
+        "busy_cycle": 0xABC,
+        "delay_cycle": 0x1234,
+        "width_cycle": 0x56,
+        "tick_start": 0x789A,
+        "tick_duration": 0x12345678,
+        "tick_initial": 0x9ABC,
+    }
+    base.update(overrides)
+    return base
 
 
 def normalize_width_bits(value: DataWidthLE8Like) -> WidthBitsLE8:
@@ -740,6 +838,754 @@ class TestOfflineFrameGenV2:
         with pytest.raises(ValueError, match="thread_id"):
             OfflineFrameGenV2.gen_complete_frame(
                 pkt_offset, pkt_ncopy, Off_Ctrl3_V2.THREAD_ID_MASK + 1
+            )
+
+
+class TestOnlineFrameGenV2:
+    def test_cf1(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        core_reg = build_online_v2_core_reg_params()
+
+        frames = OnlineFrameGenV2.gen_config_frame1(pkt_offset, core_reg, pkt_ncopy, 0)
+        update_core_xy, update_core_x, update_core_y = coordzxy_to_sign_magnitude(
+            (
+                core_reg["update_core_xy"],
+                core_reg["update_core_x"],
+                core_reg["update_core_y"],
+            )
+        )
+        test_core_xy, test_core_x, test_core_y_expected = coordzxy_to_sign_magnitude(
+            (
+                core_reg["test_core_xy"],
+                core_reg["test_core_x"],
+                core_reg["test_core_y"],
+            )
+        )
+
+        neuron_number = (
+            bit_field(
+                frames[1],
+                On_Cfg1_V2.Word1.NEURON_NUMBER_HIGH10_OFFSET,
+                On_Cfg1_V2.Word1.NEURON_NUMBER_HIGH10_MASK,
+            )
+            << 3
+        ) | bit_field(
+            frames[2],
+            On_Cfg1_V2.Word2.NEURON_NUMBER_LOW3_OFFSET,
+            On_Cfg1_V2.Word2.NEURON_NUMBER_LOW3_MASK,
+        )
+        scale_out_bits = (
+            bit_field(
+                frames[2],
+                On_Cfg1_V2.Word2.SCALE_OUT_HIGH15_OFFSET,
+                On_Cfg1_V2.Word2.SCALE_OUT_HIGH15_MASK,
+            )
+            << 1
+        ) | bit_field(
+            frames[3],
+            On_Cfg1_V2.Word3.SCALE_OUT_LOW1_OFFSET,
+            On_Cfg1_V2.Word3.SCALE_OUT_LOW1_MASK,
+        )
+        test_core_y = (
+            bit_field(
+                frames[3],
+                On_Cfg1_V2.Word3.TEST_CORE_Y_HIGH1_OFFSET,
+                On_Cfg1_V2.Word3.TEST_CORE_Y_HIGH1_MASK,
+            )
+            << 5
+        ) | bit_field(
+            frames[4],
+            On_Cfg1_V2.Word4.TEST_CORE_Y_LOW5_OFFSET,
+            On_Cfg1_V2.Word4.TEST_CORE_Y_LOW5_MASK,
+        )
+
+        assert frames.dtype == FRAME_DTYPE
+        assert frames.size == 6
+        assert parse_package_header(frames) == (
+            FramePackageType.CONF_TESTOUT.value,
+            0,
+            5,
+        )
+        assert (
+            bit_field(
+                frames[1],
+                On_Cfg1_V2.Word1.WORK_MODE_OFFSET,
+                On_Cfg1_V2.Word1.WORK_MODE_MASK,
+            )
+            == core_reg["work_mode"]
+        )
+        assert neuron_number == core_reg["neuron_number"]
+        assert scale_out_bits == scalar_bf16_bits(core_reg["scale_out"])
+        assert bit_field(
+            frames[2],
+            On_Cfg1_V2.Word2.SCALE_IN_OFFSET,
+            On_Cfg1_V2.Word2.SCALE_IN_MASK,
+        ) == scalar_bf16_bits(core_reg["scale_in"])
+        assert bit_field(
+            frames[3],
+            On_Cfg1_V2.Word3.BIAS_OUT_OFFSET,
+            On_Cfg1_V2.Word3.BIAS_OUT_MASK,
+        ) == scalar_bf16_bits(core_reg["bias_out"])
+        assert bit_field(
+            frames[3],
+            On_Cfg1_V2.Word3.LEARNING_RATE_OFFSET,
+            On_Cfg1_V2.Word3.LEARNING_RATE_MASK,
+        ) == scalar_bf16_bits(core_reg["learning_rate"])
+        assert (
+            bit_field(
+                frames[3],
+                On_Cfg1_V2.Word3.UPDATE_CORE_XY_OFFSET,
+                On_Cfg1_V2.Word3.UPDATE_CORE_XY_MASK,
+            )
+            == update_core_xy
+        )
+        assert (
+            bit_field(
+                frames[3],
+                On_Cfg1_V2.Word3.UPDATE_CORE_Y_OFFSET,
+                On_Cfg1_V2.Word3.UPDATE_CORE_Y_MASK,
+            )
+            == update_core_y
+        )
+        assert (
+            bit_field(
+                frames[3],
+                On_Cfg1_V2.Word3.TEST_CORE_XY_OFFSET,
+                On_Cfg1_V2.Word3.TEST_CORE_XY_MASK,
+            )
+            == test_core_xy
+        )
+        assert (
+            bit_field(
+                frames[3],
+                On_Cfg1_V2.Word3.TEST_CORE_X_OFFSET,
+                On_Cfg1_V2.Word3.TEST_CORE_X_MASK,
+            )
+            == test_core_x
+        )
+        assert test_core_y == test_core_y_expected
+        assert (
+            bit_field(
+                frames[5],
+                On_Cfg1_V2.Word5.TICK_DURATION_OFFSET,
+                On_Cfg1_V2.Word5.TICK_DURATION_MASK,
+            )
+            == core_reg["tick_duration"]
+        )
+
+    def test_cf1_rejects_invalid_core_params(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+
+        with pytest.raises(ValueError, match="update_core_xy"):
+            OnlineFrameGenV2.gen_config_frame1(
+                pkt_offset,
+                build_online_v2_core_reg_params(update_core_xy=32),
+                pkt_ncopy,
+                0,
+            )
+
+    @pytest.mark.parametrize("act_dtype", [np.int16, np.float32])
+    def test_cf2(self, v2_packet_route, act_dtype):
+        pkt_offset, _ = v2_packet_route
+        arr_pot = np.arange(-128, 128, dtype=np.int32)
+        if act_dtype == np.float32:
+            arr_act = (np.arange(256, dtype=np.float32) / 16) - np.float32(8.0)
+        else:
+            arr_act = np.arange(-128, 128, dtype=act_dtype)
+
+        frames = OnlineFrameGenV2.gen_config_frame2(pkt_offset, arr_pot, arr_act)
+
+        assert frames.size == 257
+
+        arr_pot2, arr_act_bits = extract_online_lut_from_cf2(frames)
+        assert np.array_equal(arr_pot, arr_pot2)
+        if act_dtype == np.float32:
+            expected_act_bits = array_bf16_bits(arr_act)
+            assert np.array_equal(arr_act_bits, expected_act_bits)
+            assert np.array_equal(
+                bf16_bits_to_float32(arr_act_bits),
+                bf16_bits_to_float32(expected_act_bits),
+            )
+        else:
+            assert np.array_equal(arr_act_bits.view(act_dtype), arr_act)
+
+    def test_cf2_rejects_mismatched_lut_size(self, v2_packet_route):
+        pkt_offset, _ = v2_packet_route
+        arr_pot = np.arange(255, dtype=np.int32)
+        arr_act = np.arange(256, dtype=np.int16)
+
+        with pytest.raises(ValueError, match="same size"):
+            OnlineFrameGenV2.gen_config_frame2(pkt_offset, arr_pot, arr_act)
+
+    @pytest.mark.parametrize("n_package", [0, 1, 100, 1000, 8000])
+    def test_gen_config_frame3_pkg_header(self, v2_packet_route, n_package):
+        pkt_offset, _ = v2_packet_route
+        frames = OnlineFrameGenV2.gen_config_frame3_pkg_header(
+            pkt_offset, 12, n_package
+        )
+
+        assert frames.dtype == FRAME_DTYPE
+        assert frames.shape == (1,)
+        assert single_frame_header_check(frames[0], FH.CONFIG_TYPE3)
+        assert parse_package_header(frames) == (
+            FramePackageType.CONF_TESTOUT.value,
+            12,
+            n_package,
+        )
+
+    def test_gen_pkg_half_neu_fields(self):
+        dest_info = build_v2_dest_info_params(
+            tick_relative=0x7E,
+            addr_axon=0xAB,
+            addr_core_xy=-1,
+            addr_core_x=2,
+            addr_core_y=-3,
+            addr_copy_xy=4,
+            addr_copy_x=-5,
+            addr_copy_y=6,
+        )
+        half_attrs = build_v2_half_attrs_params(
+            weight_skew=0xABC,
+            weight_address_start=0x123,
+            weight_address_end=0x456,
+            output_type=OutputType.POTENTIAL,
+            fold_type=FoldType.UNFOLDED,
+            neuron_type=NeuronType.FULL,
+            vjt=np.float32(1.25),
+        )
+
+        pkg_half_neu = OnlineFrameGenV2._gen_pkg_half_neu(dest_info, half_attrs)
+        _, _, addr_core_y = coordzxy_to_sign_magnitude(
+            (
+                dest_info["addr_core_xy"],
+                dest_info["addr_core_x"],
+                dest_info["addr_core_y"],
+            )
+        )
+        _, addr_copy_x, _ = coordzxy_to_sign_magnitude(
+            (
+                dest_info["addr_copy_xy"],
+                dest_info["addr_copy_x"],
+                dest_info["addr_copy_y"],
+            )
+        )
+
+        assert pkg_half_neu.dtype == FRAME_DTYPE
+        assert pkg_half_neu.shape == (2,)
+        assert bit_field(
+            pkg_half_neu[0],
+            On_Cfg3_V2.Full.Word1.WEIGHT_SKEW_LOW4_OFFSET,
+            On_Cfg3_V2.Full.Word1.WEIGHT_SKEW_LOW4_MASK,
+        ) == (half_attrs["weight_skew"] & On_Cfg3_V2.Full.Word1.WEIGHT_SKEW_LOW4_MASK)
+        assert bit_field(
+            pkg_half_neu[1],
+            On_Cfg3_V2.Full.Word2.WEIGHT_SKEW_HIGH12_OFFSET,
+            On_Cfg3_V2.Full.Word2.WEIGHT_SKEW_HIGH12_MASK,
+        ) == (half_attrs["weight_skew"] >> 4)
+        assert bit_field(
+            pkg_half_neu[0],
+            On_Cfg3_V2.Full.Word1.VJT_OFFSET,
+            On_Cfg3_V2.Full.Word1.VJT_MASK,
+        ) == scalar_bits(half_attrs["vjt"], np.float32)
+        assert (
+            bit_field(
+                pkg_half_neu[1],
+                On_Cfg3_V2.Full.Word2.ADDR_CORE_Y_OFFSET,
+                On_Cfg3_V2.Full.Word2.ADDR_CORE_Y_MASK,
+            )
+            == addr_core_y
+        )
+        assert (
+            bit_field(
+                pkg_half_neu[1],
+                On_Cfg3_V2.Full.Word2.ADDR_COPY_X_OFFSET,
+                On_Cfg3_V2.Full.Word2.ADDR_COPY_X_MASK,
+            )
+            == addr_copy_x
+        )
+
+    def test_gen_pkg_half_neu_rejects_invalid_dest_info(self):
+        with pytest.raises(ValueError, match="addr_axon"):
+            OnlineFrameGenV2.gen_config_frame3_pkg_half(
+                build_v2_dest_info_params(addr_axon=0x1FF),
+                build_v2_half_attrs_params(vjt=np.float32(0.5)),
+            )
+
+    def test_gen_pkg_full_neu_fields(self):
+        dest_info = build_v2_dest_info_params(
+            tick_relative=9,
+            addr_axon=17,
+            addr_core_xy=1,
+            addr_core_x=2,
+            addr_core_y=3,
+            addr_copy_xy=4,
+            addr_copy_x=5,
+            addr_copy_y=6,
+        )
+        full_attrs1 = build_v2_half_attrs_params(
+            weight_skew=0x123,
+            weight_address_start=10,
+            weight_address_end=20,
+            output_type=OutputType.POTENTIAL,
+            fold_type=FoldType.UNFOLDED,
+            neuron_type=NeuronType.FULL,
+            vjt=np.float32(2.5),
+        )
+        full_attrs2 = build_v2_full_attrs_part2_params(
+            reset_mode=ResetMode.MODE_LINEAR,
+            reset_v=np.float16(-0.75),
+            threshold_neg_mode=ThresholdNegMode.FLOOR,
+            threshold_pos_mode=ThresholdPosMode.CEILING,
+            threshold_neg=np.float32(-2.5),
+            threshold_pos=np.float32(3.25),
+            lateral_inhibition=LateralInhibitionMode.ENABLE,
+            leak_multi_sequence=LeakMultiComparisonOrder.AFTER_COMPARE,
+            leak_multi_input=LeakMultiInputMode.ENABLE,
+            leak_multi_mode=LeakMultiMode.ENABLE,
+            leak_add_mode=LeakAddMode.BACKWARD,
+            leak_tau=17,
+            leak_v=np.float16(-1.5),
+            weight_compress=WeightCompressType.SPARSE,
+            vjt_initial=np.float16(0.5),
+        )
+
+        pkg_full_neu = OnlineFrameGenV2._gen_pkg_full_neu(
+            dest_info, full_attrs1, full_attrs2
+        )
+
+        threshold_pos_bits = (
+            bit_field(
+                pkg_full_neu[3],
+                On_Cfg3_V2.Full.Word4.THRESHOLD_POS_HIGH12_OFFSET,
+                On_Cfg3_V2.Full.Word4.THRESHOLD_POS_HIGH12_MASK,
+            )
+            << 20
+        ) | bit_field(
+            pkg_full_neu[2],
+            On_Cfg3_V2.Full.Word3.THRESHOLD_POS_LOW20_OFFSET,
+            On_Cfg3_V2.Full.Word3.THRESHOLD_POS_LOW20_MASK,
+        )
+
+        assert pkg_full_neu.dtype == FRAME_DTYPE
+        assert pkg_full_neu.shape == (4,)
+        assert threshold_pos_bits == scalar_bits(
+            full_attrs2["threshold_pos"], np.float32
+        )
+        assert bit_field(
+            pkg_full_neu[3],
+            On_Cfg3_V2.Full.Word4.THRESHOLD_NEG_OFFSET,
+            On_Cfg3_V2.Full.Word4.THRESHOLD_NEG_MASK,
+        ) == scalar_bits(full_attrs2["threshold_neg"], np.float32)
+        assert bit_field(
+            pkg_full_neu[3],
+            On_Cfg3_V2.Full.Word4.RESET_V_OFFSET,
+            On_Cfg3_V2.Full.Word4.RESET_V_MASK,
+        ) == scalar_bf16_bits(full_attrs2["reset_v"])
+        assert bit_field(
+            pkg_full_neu[2],
+            On_Cfg3_V2.Full.Word3.LEAK_V_OFFSET,
+            On_Cfg3_V2.Full.Word3.LEAK_V_MASK,
+        ) == scalar_bf16_bits(full_attrs2["leak_v"])
+        assert bit_field(
+            pkg_full_neu[2],
+            On_Cfg3_V2.Full.Word3.VJT_INITIAL_OFFSET,
+            On_Cfg3_V2.Full.Word3.VJT_INITIAL_MASK,
+        ) == scalar_bf16_bits(full_attrs2["vjt_initial"])
+        assert (
+            bit_field(
+                pkg_full_neu[2],
+                On_Cfg3_V2.Full.Word3.WEIGHT_COMPRESS_OFFSET,
+                On_Cfg3_V2.Full.Word3.WEIGHT_COMPRESS_MASK,
+            )
+            == WeightCompressType.SPARSE.value
+        )
+
+    def test_gen_pkg_folded_neu_fields(self):
+        attrs1 = build_v2_folded_attrs_part1_params(
+            fold_range_xy=2,
+            fold_range_x=3,
+            fold_range_y=4,
+            fold_skew_xy=5,
+            fold_skew_x=6,
+            fold_skew_y=0x155,
+            fold_axon_xy=7,
+            fold_axon_x=8,
+            fold_axon_y=9,
+            fold_number=24,
+        )
+        attrs2_1 = build_v2_folded_attrs_part2_params(
+            fold_vjt_3=np.float32(1.0),
+            fold_vjt_2=np.float32(-2.5),
+            fold_vjt_1=np.float32(3.25),
+            fold_vjt_0=np.float32(-4.75),
+        )
+        attrs2_2 = build_v2_folded_attrs_part2_params(
+            fold_vjt_3=np.float32(10.0),
+            fold_vjt_2=np.float32(20.0),
+            fold_vjt_1=np.float32(30.0),
+            fold_vjt_0=np.float32(40.0),
+        )
+
+        attrs1_dump = validated_dump(OnlineNeuFoldedAttrsV2Part1, attrs1)
+        attrs2_1_dump = validated_dump(OnlineNeuFoldedAttrsV2Part2, attrs2_1)
+        attrs2_2_dump = validated_dump(OnlineNeuFoldedAttrsV2Part2, attrs2_2)
+
+        pkg_folded_neu = OnlineFrameGenV2._gen_pkg_folded_neu(
+            attrs1_dump, attrs2_1_dump, attrs2_2_dump
+        )
+
+        assert pkg_folded_neu.dtype == FRAME_DTYPE
+        assert pkg_folded_neu.shape == (6,)
+        assert bit_field(
+            pkg_folded_neu[0],
+            On_Cfg3_V2.Fold.Word1.FOLD_SKEW_Y_LOW2_OFFSET,
+            On_Cfg3_V2.Fold.Word1.FOLD_SKEW_Y_LOW2_MASK,
+        ) == (attrs1["fold_skew_y"] & On_Cfg3_V2.Fold.Word1.FOLD_SKEW_Y_LOW2_MASK)
+        assert bit_field(
+            pkg_folded_neu[1],
+            On_Cfg3_V2.Fold.Word2.FOLD_SKEW_Y_HIGH9_OFFSET,
+            On_Cfg3_V2.Fold.Word2.FOLD_SKEW_Y_HIGH9_MASK,
+        ) == (attrs1["fold_skew_y"] >> 2)
+        assert bit_field(
+            pkg_folded_neu[2],
+            On_Cfg3_V2.Fold.Word3.FOLD_VJT_0_OFFSET,
+            On_Cfg3_V2.Fold.Word3.FOLD_VJT_0_MASK,
+        ) == scalar_bits(attrs2_1["fold_vjt_0"], np.float32)
+        assert bit_field(
+            pkg_folded_neu[3],
+            On_Cfg3_V2.Fold.Word4.FOLD_VJT_3_OFFSET,
+            On_Cfg3_V2.Fold.Word4.FOLD_VJT_3_MASK,
+        ) == scalar_bits(attrs2_1["fold_vjt_3"], np.float32)
+        assert bit_field(
+            pkg_folded_neu[4],
+            On_Cfg3_V2.Fold.Word3.FOLD_VJT_1_OFFSET,
+            On_Cfg3_V2.Fold.Word3.FOLD_VJT_1_MASK,
+        ) == scalar_bits(attrs2_2["fold_vjt_1"], np.float32)
+        assert bit_field(
+            pkg_folded_neu[5],
+            On_Cfg3_V2.Fold.Word4.FOLD_VJT_2_OFFSET,
+            On_Cfg3_V2.Fold.Word4.FOLD_VJT_2_MASK,
+        ) == scalar_bits(attrs2_2["fold_vjt_2"], np.float32)
+
+    @pytest.mark.parametrize(
+        "wrapper_name,args,expected_size",
+        [
+            (
+                "gen_config_frame3_pkg_half",
+                (
+                    build_v2_dest_info_params(),
+                    build_v2_half_attrs_params(vjt=np.float32(0.5)),
+                ),
+                2,
+            ),
+            (
+                "gen_config_frame3_pkg_full",
+                (
+                    build_v2_dest_info_params(),
+                    build_v2_half_attrs_params(vjt=np.float32(0.5)),
+                    build_v2_full_attrs_part2_params(
+                        reset_v=np.float16(0.25),
+                        threshold_neg=np.float32(-1.0),
+                        threshold_pos=np.float32(1.0),
+                        leak_v=np.float16(2.0),
+                        vjt_initial=np.float16(0.75),
+                    ),
+                ),
+                4,
+            ),
+            (
+                "gen_config_frame3_pkg_folded",
+                (
+                    build_v2_folded_attrs_part1_params(),
+                    [build_v2_folded_attrs_part2_params(fold_vjt_0=np.float32(1.0))],
+                ),
+                4,
+            ),
+        ],
+        ids=["half", "full", "folded"],
+    )
+    def test_gen_config_frame3_pkg_wrappers(self, wrapper_name, args, expected_size):
+        result = getattr(OnlineFrameGenV2, wrapper_name)(*args)
+
+        assert result.size == expected_size
+
+    def test_gen_config_frame3_pkg_folded_wrapper_rejects_incomplete_attrs(self):
+        with pytest.raises(ValueError, match="incomplete"):
+            OnlineFrameGenV2.gen_config_frame3_pkg_folded(
+                build_v2_folded_attrs_part1_params(), []
+            )
+
+    def test_gen_config_frame3_pkg_neu_valid_combinations(self):
+        result = OnlineFrameGenV2.gen_config_frame3_pkg_neu(
+            build_v2_dest_info_params(),
+            build_v2_half_attrs_params(vjt=np.float32(0.5)),
+            build_v2_full_attrs_part2_params(
+                reset_v=np.float16(0.25),
+                threshold_neg=np.float32(-1.0),
+                threshold_pos=np.float32(1.0),
+                leak_v=np.float16(2.0),
+                vjt_initial=np.float16(0.75),
+            ),
+            build_v2_folded_attrs_part1_params(),
+            [
+                build_v2_folded_attrs_part2_params(fold_vjt_0=np.float32(1.0)),
+                build_v2_folded_attrs_part2_params(fold_vjt_0=np.float32(2.0)),
+            ],
+        )
+
+        assert [pkg.size for pkg in result] == [2, 4, 6]
+
+    @pytest.mark.parametrize(
+        "args,error_match",
+        [
+            (
+                (
+                    build_v2_dest_info_params(),
+                    None,
+                    build_v2_full_attrs_part2_params(),
+                    None,
+                    [],
+                ),
+                "full neuron.*missing part1",
+            ),
+            (
+                (
+                    build_v2_dest_info_params(),
+                    build_v2_half_attrs_params(),
+                    None,
+                    build_v2_folded_attrs_part1_params(),
+                    [],
+                ),
+                "folded neuron.*missing part2",
+            ),
+            (
+                (
+                    build_v2_dest_info_params(),
+                    build_v2_half_attrs_params(),
+                    None,
+                    None,
+                    [build_v2_folded_attrs_part2_params()],
+                ),
+                "folded neuron.*missing part1",
+            ),
+        ],
+        ids=["full-missing-part1", "folded-missing-part2", "folded-missing-part1"],
+    )
+    def test_gen_config_frame3_pkg_neu_rejects_invalid_combinations(
+        self, args, error_match
+    ):
+        with pytest.raises(ValueError, match=error_match):
+            OnlineFrameGenV2.gen_config_frame3_pkg_neu(*args)
+
+    @pytest.mark.parametrize(
+        "weight,csc_compress,expected_builder",
+        [
+            (np.array([1, -2, 3, 4, 5], dtype=np.int16), False, weight_dense_u16_pack),
+            (
+                np.array([0, 1, 0, -2, 0, 3, 0, 4], dtype=np.int16),
+                CSCAccelerateMode.ENABLE,
+                weight_csc_u16_pack,
+            ),
+        ],
+        ids=["dense", "csc"],
+    )
+    def test_gen_config_frame3_weight_pkg(self, weight, csc_compress, expected_builder):
+        result = OnlineFrameGenV2.gen_config_frame3_weight_pkg(weight, csc_compress)
+        expected = expected_builder(weight)
+
+        assert np.array_equal(result, expected)
+
+    def test_gen_config_frame3_weight_pkg_dense_bf16_float(self):
+        weight = np.array([1.5, -2.0, 3.25], dtype=np.float32)
+        result = OnlineFrameGenV2.gen_config_frame3_weight_pkg(weight, False)
+        expected_bits = array_bf16_bits(weight)
+
+        assert result.shape == (2,)
+        assert (
+            bit_field(
+                result[0],
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_0_OFFSET,
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_0_MASK,
+            )
+            == expected_bits[0]
+        )
+        assert (
+            bit_field(
+                result[0],
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_1_OFFSET,
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_1_MASK,
+            )
+            == expected_bits[1]
+        )
+        assert (
+            bit_field(
+                result[0],
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_2_OFFSET,
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_2_MASK,
+            )
+            == expected_bits[2]
+        )
+        assert (
+            bit_field(
+                result[0],
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_3_OFFSET,
+                On_Cfg3_V2.WeightDense.Word1.WEIGHT_3_MASK,
+            )
+            == 0
+        )
+
+    def test_gen_config_frame3_weight_pkg_rejects_non_1d_weight(self):
+        with pytest.raises(ValueError, match="1D"):
+            OnlineFrameGenV2.gen_config_frame3_weight_pkg(
+                np.ones((2, 2), dtype=np.int16)
+            )
+
+    def test_cf4(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        input_array = np.arange(12, dtype=FRAME_DTYPE)
+
+        frames = OnlineFrameGenV2.gen_config_frame4(
+            pkt_offset, input_array, pkt_ncopy, 3
+        )
+
+        assert frames.dtype == FRAME_DTYPE
+        assert frames.size == 13
+        assert parse_package_header(frames) == (
+            FramePackageType.CONF_TESTOUT.value,
+            3,
+            input_array.size,
+        )
+        assert np.array_equal(frames[1:], input_array)
+
+    @pytest.mark.parametrize(
+        "method_name,header,data,expected_bytes",
+        [
+            (
+                "gen_work_frame1",
+                FH.WORK_TYPE1,
+                np.array([0x1234, 0], dtype=np.uint16),
+                np.array([0x34, 0x12], dtype=np.uint8),
+            ),
+            (
+                "gen_work_frame2",
+                FH.WORK_TYPE2,
+                np.array([1.5, 0.0], dtype=np.float16),
+                np.array([0x00, 0x3E], dtype=np.uint8),
+            ),
+            (
+                "gen_work_frame3",
+                FH.WORK_TYPE3,
+                np.array([-2.5, 0.0], dtype=np.float32),
+                np.array([0x00, 0x00, 0x20, 0xC0], dtype=np.uint8),
+            ),
+        ],
+        ids=["wf1-u16", "wf2-f16", "wf3-f32"],
+    )
+    def test_work_frames(
+        self, v2_packet_route, method_name, header, data, expected_bytes
+    ):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        wf = getattr(OnlineFrameGenV2, method_name)(
+            pkt_offset,
+            pkt_ncopy,
+            np.array([3, 4]),
+            np.array([5, 6]),
+            LCN_EX.LCN_1X,
+            data,
+        )
+
+        assert wf.dtype == FRAME_DTYPE
+        assert wf.size == expected_bytes.size
+        assert all(single_frame_header_check(frame, header) for frame in wf)
+        assert np.array_equal(
+            (wf & On_Work1_V2.DATA_MASK).astype(np.uint8), expected_bytes
+        )
+        assert np.all(
+            ((wf >> On_Work1_V2.TIMESTEP_AXON_OFFSET) & On_Work1_V2.TIMESTEP_AXON_MASK)
+            == ((3 << 8) | 5)
+        )
+
+    def test_work_frame4_supports_target_lcn_8(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        wf = OnlineFrameGenV2.gen_work_frame4(
+            pkt_offset,
+            pkt_ncopy,
+            np.array([7]),
+            np.array([0xBEEF]),
+            8,
+            np.array([1], dtype=np.uint8),
+        )
+
+        assert wf.shape == (1,)
+        assert (
+            bit_field(
+                wf[0], On_Work1_V2.TIMESTEP_AXON_OFFSET, On_Work1_V2.TIMESTEP_AXON_MASK
+            )
+            == 0xBEEF
+        )
+
+    @pytest.mark.parametrize(
+        "timesteps, axons, data",
+        [
+            ([1, 2], [3], [4, 5]),
+            ([1, 2], [3, 4], [5]),
+        ],
+    )
+    def test_work_frame_rejects_mismatched_lengths(
+        self, v2_packet_route, timesteps, axons, data
+    ):
+        pkt_offset, pkt_ncopy = v2_packet_route
+
+        with pytest.raises(ValueError, match="size"):
+            OnlineFrameGenV2.gen_work_frame1(
+                pkt_offset, pkt_ncopy, timesteps, axons, LCN_EX.LCN_1X, data
+            )
+
+    def test_control_frames(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        ctrl1 = OnlineFrameGenV2.gen_control_frame1(pkt_offset, pkt_ncopy, 123)
+        ctrl2 = OnlineFrameGenV2.gen_control_frame2(pkt_offset, pkt_ncopy)
+        complete = OnlineFrameGenV2.gen_complete_frame(pkt_offset, pkt_ncopy, 7)
+        update = OnlineFrameGenV2.gen_update_frame(pkt_offset, pkt_ncopy, 0x12345)
+
+        assert single_frame_header_check(ctrl1[0], FH.CTRL_TYPE1)
+        assert single_frame_header_check(ctrl2[0], FH.CTRL_TYPE2)
+        assert single_frame_header_check(complete[0], FH.CTRL_TYPE3)
+        assert single_frame_header_check(update[0], FH.CTRL_TYPE4)
+        assert (
+            bit_field(ctrl1[0], FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK)
+            == 123
+        )
+        assert (
+            bit_field(
+                complete[0], FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK
+            )
+            == 7
+        )
+        assert (
+            bit_field(update[0], FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK)
+            == 0x12345
+        )
+
+    def test_control_frame1_rejects_overflow(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        with pytest.raises(ValueError, match="overflow"):
+            OnlineFrameGenV2.gen_control_frame1(
+                pkt_offset, pkt_ncopy, On_Ctrl1_V2.NUM_TIMESTEP_MASK + 1
+            )
+
+    def test_complete_frame_rejects_overflow(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        with pytest.raises(ValueError, match="thread_id"):
+            OnlineFrameGenV2.gen_complete_frame(
+                pkt_offset, pkt_ncopy, On_Ctrl3_V2.THREAD_ID_MASK + 1
+            )
+
+    def test_update_frame_rejects_overflow(self, v2_packet_route):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        with pytest.raises(ValueError, match="ext_multicast_addr"):
+            OnlineFrameGenV2.gen_update_frame(
+                pkt_offset, pkt_ncopy, On_Ctrl4_V2.EXT_MULTICAST_ADDR_MASK + 1
             )
 
 


### PR DESCRIPTION
## Summary

This PR adds online-core v2 support in `framelib`, including frame definitions, frame generation, and corresponding tests.

## Changes

- add online v2 frame definitions in `paicorelib/framelib/frame_defs.py`
- add online v2 frame generation in `paicorelib/framelib/frame_gen_v2.py`
- add online v2 test coverage in `tests/framelib/test_frame_gen_v2.py`
- keep existing legacy/offline code paths unchanged
- keep `tests/framelib/test_base.py` unchanged

## Notes

- implementation follows the existing v2/offline style as closely as possible
- endian handling and bit-field packing were aligned with the online v2 frame definitions
- only incremental updates were made for v2 support; old version behavior was not modified

## Validation

- online v2 tests in `tests/framelib/test_frame_gen_v2.py` passed
