### PR TITLE
Bugfix(csc): work-frame packing & CSC sparse weight mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paicorelib"
-version = "2.0.0b4"
+version = "2.0.0b5"
 description = "Library of PAICORE"
 authors = [{ name = "Ziru Pan", email = "zrpan@stu.pku.edu.cn" }]
 license = "GPL-3.0-or-later"

--- a/src/paicorelib/framelib/frame_gen_v2.py
+++ b/src/paicorelib/framelib/frame_gen_v2.py
@@ -1,9 +1,8 @@
-import math
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -71,48 +70,45 @@ DataWidthLE8 = Literal[1, 2, 4, 8]
 DataWidthLE8Like = DataWidth | DataWidthLE8
 OfflineWorkFrameFormat = type[Off_Work1_V2 | Off_Work2_V2]
 OnlineWorkFrameFormat = type[On_Work1_V2 | On_Work2_V2 | On_Work3_V2 | On_Work4_V2]
-PackWorkAddr = Callable[[FrameArrayType, FrameArrayType, int], FrameArrayType]
+PackWorkAddr = Callable[[FrameArrayType, FrameArrayType], FrameArrayType]
 N_FRAME_PER_LUT_RAM = 256
+OFFLINE_WORK_TOTAL_WIDTH = 17
+OFFLINE_WORK_AXON_WIDTH = 9
+OFFLINE_WORK_TIMESTEP_WIDTH = OFFLINE_WORK_TOTAL_WIDTH - OFFLINE_WORK_AXON_WIDTH
+ONLINE_WORK_TOTAL_WIDTH = 16
+ONLINE_WORK_AXON_WIDTH = 8
+ONLINE_WORK_TIMESTEP_WIDTH = ONLINE_WORK_TOTAL_WIDTH - ONLINE_WORK_AXON_WIDTH
+CSC_WEIGHT_INDEX_BITS = 16
+CSC_WEIGHT_INDEX_MAX = (1 << CSC_WEIGHT_INDEX_BITS) - 1
 
 _p = pack_field
 
 
-def _normalize_width_le8(
-    width: DataWidthLE8Like, *, name: str = "width"
-) -> DataWidthLE8:
+def _normalize_width_le8(width: DataWidthLE8Like) -> DataWidthLE8:
     width_bits = (1 << width.value) if isinstance(width, DataWidth) else int(width)
     if width_bits not in (1, 2, 4, 8):
-        raise ValueError(f"'{name}' only supports 1/2/4/8-bit widths, got {width}.")
-
-    return cast(DataWidthLE8, width_bits)
+        raise ValueError(f"only supports 1/2/4/8-bit widths, got {width}.")
+    return width_bits
 
 
 def _normalize_lcn(target_lcn: LCN_EX | int) -> int:
     """Return the integer LCN index used by V2 work-frame address packing."""
     if isinstance(target_lcn, LCN_EX):
-        target_lcn = target_lcn.value
-    elif target_lcn < 0 or target_lcn > 7:
-        raise ValueError(f"'target_lcn' must be in range [0, 7], got {target_lcn}.")
-    return int(target_lcn)
-
-
-def _offline_lcn_to_axon_width(target_lcn: int) -> int:
-    return 9 + target_lcn
-
-
-def _online_lcn_to_axon_width(target_lcn: int) -> int:
-    return 8 + target_lcn
+        return target_lcn.value
+    if target_lcn < LCN_EX.LCN_1X or target_lcn > LCN_EX.LCN_128X:
+        raise ValueError(
+            f"'target_lcn' must be in range [{LCN_EX.LCN_1X}, {LCN_EX.LCN_128X}], got {target_lcn}."
+        )
+    return target_lcn
 
 
 def _pack_offline_work_addr(
-    ts: FrameArrayType,
-    ax: FrameArrayType,
-    axon_width: int,
-    F: type[Off_Work1_V2 | Off_Work2_V2],
+    ts: FrameArrayType, ax: FrameArrayType, F: type[Off_Work1_V2 | Off_Work2_V2]
 ) -> FrameArrayType:
     """Pack offline work-frame timestamp and axon fields."""
-    ts_width = 17 - axon_width
-    ts_ax_addr = ((ts & _mask(ts_width)) << axon_width) | (ax & _mask(axon_width))
+    ts_ax_addr = (
+        (ts & _mask(OFFLINE_WORK_TIMESTEP_WIDTH)) << OFFLINE_WORK_AXON_WIDTH
+    ) | (ax & _mask(OFFLINE_WORK_AXON_WIDTH))
     return _p(ts_ax_addr >> 16, F.TIMESTEP_HIGH7_OFFSET, F.TIMESTEP_HIGH7_MASK) | (
         (ts_ax_addr & _mask(16)) << F.AXON_ADDR_OFFSET
     ).astype(FRAME_DTYPE)
@@ -121,12 +117,12 @@ def _pack_offline_work_addr(
 def _pack_online_work_addr(
     ts: FrameArrayType,
     ax: FrameArrayType,
-    axon_width: int,
     F: type[On_Work1_V2 | On_Work2_V2 | On_Work3_V2 | On_Work4_V2],
 ) -> FrameArrayType:
     """Pack online work-frame timestamp and axon fields."""
-    ts_width = 16 - axon_width
-    ts_ax_addr = ((ts & _mask(ts_width)) << axon_width) | (ax & _mask(axon_width))
+    ts_ax_addr = (
+        (ts & _mask(ONLINE_WORK_TIMESTEP_WIDTH)) << ONLINE_WORK_AXON_WIDTH
+    ) | (ax & _mask(ONLINE_WORK_AXON_WIDTH))
     return _p(ts_ax_addr, F.TIMESTEP_AXON_OFFSET, F.TIMESTEP_AXON_MASK).astype(
         FRAME_DTYPE
     )
@@ -138,7 +134,7 @@ def _as_1d_payload_array(data: ArrayLike) -> np.ndarray:
 
 def _normalize_work_frame_tick_ax(
     tick_relatives: ArrayLike, axons: ArrayLike
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, FrameArrayType]:
     tick = np.asarray(tick_relatives).ravel()
     ax = np.asarray(axons, dtype=FRAME_DTYPE).ravel()
 
@@ -152,10 +148,7 @@ def _normalize_work_frame_tick_ax(
 
 
 def _resolve_work_frame_timestep(
-    tick_relatives: np.ndarray,
-    target_lcn: int,
-    timestep: int,
-    total_ts_width: int,
+    tick_relatives: np.ndarray, target_lcn: int, timestep: int, timestep_width: int
 ) -> FrameArrayType:
     """Resolve mapping-local ticks into the timestamp written to work frames.
 
@@ -164,44 +157,49 @@ def _resolve_work_frame_timestep(
 
     ``cur_ts = (timestep << target_lcn) + tick_relative``
     """
-    if timestep < 0:
-        raise ValueError(f"'timestep' must be non-negative, got {timestep}.")
+    _check_work_frame_tick_relative(tick_relatives, target_lcn)
+    timestep_base = _work_frame_timestep_base(target_lcn, timestep, timestep_width)
+    return _resolve_work_frame_timestep_from_base(tick_relatives, timestep_base)
 
-    if np.any(tick_relatives < 0):
+
+def _check_work_frame_tick_relative(
+    tick_relatives: np.ndarray, target_lcn: int
+) -> None:
+    """Validate mapping-local ticks without allocating resolved timestamps."""
+    if tick_relatives.size == 0:
+        return
+
+    tick_min, tick_max = tick_relatives.min(), tick_relatives.max()
+    if tick_min < 0:
         raise ValueError(
-            f"'tick_relatives' must be non-negative, got min {int(tick_relatives.min())}."
+            f"'tick_relatives' must be non-negative, got min {int(tick_min)}."
         )
 
     tick_limit = 1 << target_lcn
-    if np.any(tick_relatives >= tick_limit):
+    if tick_max >= tick_limit:
         raise ValueError(
             f"'tick_relatives' must be in range [0, {tick_limit}), "
-            f"got max {int(tick_relatives.max())}."
+            f"got max {int(tick_max)}."
         )
 
-    ts_limit = 1 << total_ts_width
-    timestep_base = _resolve_work_frame_timestep_base(
-        target_lcn, timestep, total_ts_width
-    )
+
+def _resolve_work_frame_timestep_from_base(
+    tick_relatives: np.ndarray, timestep_base: int
+) -> FrameArrayType:
+    if tick_relatives.size == 0:
+        return np.array([], dtype=FRAME_DTYPE)
 
     tick = tick_relatives.astype(FRAME_DTYPE, copy=False)
-    cur_ts = np.asarray(timestep_base, dtype=FRAME_DTYPE) + tick
-    if np.any(cur_ts >= ts_limit):
-        raise ValueError(
-            f"resolved timestep must be in range [0, {ts_limit}), "
-            f"got max {int(cur_ts.max())}."
-        )
-
-    return cur_ts.astype(FRAME_DTYPE, copy=False)
+    return tick + timestep_base
 
 
-def _resolve_work_frame_timestep_base(
-    target_lcn: int, timestep: int, total_ts_width: int
+def _work_frame_timestep_base(
+    target_lcn: int, timestep: int, timestep_width: int
 ) -> int:
     if timestep < 0:
         raise ValueError(f"'timestep' must be non-negative, got {timestep}.")
 
-    ts_limit = 1 << total_ts_width
+    ts_limit = 1 << timestep_width
     timestep_base = timestep << target_lcn
     if timestep_base >= ts_limit:
         raise ValueError(
@@ -239,7 +237,7 @@ class WorkFrameBase(ABC):
 
     @abstractmethod
     def pack_work_addr(
-        self, ts: FrameArrayType, ax: FrameArrayType, axon_width: int
+        self, ts: FrameArrayType, ax: FrameArrayType
     ) -> FrameArrayType: ...
 
     def load(self, payload: ArrayLike, timestep: int = 0) -> FrameArrayType:
@@ -256,9 +254,8 @@ class WorkFrameBase(ABC):
             self.axons,
             normalized_payload,
             self.target_lcn,
-            self.axon_width,
             timestep,
-            self.total_width,
+            self.total_width - self.axon_width,
             self.pack_work_addr,
         )
 
@@ -267,10 +264,8 @@ class WorkFrameBase(ABC):
 class OfflineWorkFrameBase(WorkFrameBase):
     work_format: OfflineWorkFrameFormat
 
-    def pack_work_addr(
-        self, ts: FrameArrayType, ax: FrameArrayType, axon_width: int
-    ) -> FrameArrayType:
-        return _pack_offline_work_addr(ts, ax, axon_width, self.work_format)
+    def pack_work_addr(self, ts: FrameArrayType, ax: FrameArrayType) -> FrameArrayType:
+        return _pack_offline_work_addr(ts, ax, self.work_format)
 
 
 class OfflineWorkFrame1Base(OfflineWorkFrameBase):
@@ -287,10 +282,8 @@ class OfflineWorkFrame2Base(OfflineWorkFrameBase):
 class OnlineWorkFrameBase(WorkFrameBase):
     work_format: OnlineWorkFrameFormat
 
-    def pack_work_addr(
-        self, ts: FrameArrayType, ax: FrameArrayType, axon_width: int
-    ) -> FrameArrayType:
-        return _pack_online_work_addr(ts, ax, axon_width, self.work_format)
+    def pack_work_addr(self, ts: FrameArrayType, ax: FrameArrayType) -> FrameArrayType:
+        return _pack_online_work_addr(ts, ax, self.work_format)
 
 
 class OnlineWorkFrame1Base(OnlineWorkFrameBase):
@@ -320,8 +313,7 @@ def _gen_work_frame_base(
     tick_relatives: ArrayLike,
     axons: ArrayLike,
     target_lcn: int,
-    axon_width: int,
-    total_width: int,
+    timestep_width: int,
     pack_work_addr: PackWorkAddr,
 ) -> FrameArrayType:
     """Build payload-free work-frame bases for ``timestep=0``.
@@ -337,8 +329,7 @@ def _gen_work_frame_base(
         tick_relatives,
         axons,
         target_lcn,
-        axon_width,
-        total_width,
+        timestep_width,
         pack_work_addr,
     )
     return base
@@ -351,16 +342,13 @@ def _make_work_frame_base_parts(
     tick_relatives: ArrayLike,
     axons: ArrayLike,
     target_lcn: int,
-    axon_width: int,
-    total_width: int,
+    timestep_width: int,
     pack_work_addr: PackWorkAddr,
 ) -> tuple[int, FrameArrayType, FrameArrayType, FrameArrayType]:
     tick, ax = _normalize_work_frame_tick_ax(tick_relatives, axons)
-    tick = tick.astype(FRAME_DTYPE, copy=False)
-    total_ts_width = total_width - axon_width
-    resolved_tick = _resolve_work_frame_timestep(tick, target_lcn, 0, total_ts_width)
+    resolved_tick = _resolve_work_frame_timestep(tick, target_lcn, 0, timestep_width)
     frame_dest = get_frame_dest_v2(header, pkt_offset, pkt_ncopy)
-    frame_addr = pack_work_addr(resolved_tick, ax, axon_width)
+    frame_addr = pack_work_addr(resolved_tick, ax)
     base = (frame_dest + frame_addr).astype(FRAME_DTYPE)
     return frame_dest, tick, ax, base
 
@@ -372,9 +360,8 @@ def _gen_work_frame_from_base(
     axons: FrameArrayType,
     payload: np.ndarray,
     target_lcn: int,
-    axon_width: int,
     timestep: int,
-    total_width: int,
+    timestep_width: int,
     pack_work_addr: PackWorkAddr,
 ) -> FrameArrayType:
     """Load dynamic payload and timestep into precomputed work-frame bases."""
@@ -384,53 +371,50 @@ def _gen_work_frame_from_base(
             f"{payload.size} != {base.size}."
         )
 
-    total_ts_width = total_width - axon_width
-    _resolve_work_frame_timestep(tick_relatives, target_lcn, timestep, total_ts_width)
+    if timestep == 0:
+        _work_frame_timestep_base(target_lcn, timestep, timestep_width)
+        mask = np.flatnonzero(payload)
+        if mask.size == 0:
+            return np.array([], dtype=FRAME_DTYPE)
+        return _load_work_frame_payload_from_base(base[mask], payload[mask])
 
+    _check_work_frame_tick_relative(tick_relatives, target_lcn)
+    timestep_base = _work_frame_timestep_base(target_lcn, timestep, timestep_width)
     mask = np.flatnonzero(payload)
     if mask.size == 0:
         return np.array([], dtype=FRAME_DTYPE)
 
-    return _load_work_frame_payload(
-        frame_dest,
-        tick_relatives[mask],
-        axons[mask],
-        payload[mask],
-        target_lcn,
-        axon_width,
-        timestep,
-        total_width,
-        pack_work_addr,
+    resolved_timestep = _resolve_work_frame_timestep_from_base(
+        tick_relatives[mask], timestep_base
     )
+    return _load_work_frame_payload(
+        frame_dest, resolved_timestep, axons[mask], payload[mask], pack_work_addr
+    )
+
+
+def _load_work_frame_payload_from_base(
+    frame_base: FrameArrayType, payload: np.ndarray
+) -> FrameArrayType:
+    payload_parts = _payload_to_le_bytes(payload)
+    frames = frame_base[:, np.newaxis] + payload_parts
+    return frames.reshape(-1).astype(FRAME_DTYPE, copy=False)
 
 
 def _load_work_frame_payload(
     frame_dest: int,
-    tick_relatives: FrameArrayType,
+    resolved_timestep: FrameArrayType,
     axons: FrameArrayType,
     payload: np.ndarray,
-    target_lcn: int,
-    axon_width: int,
-    timestep: int,
-    total_width: int,
     pack_work_addr: PackWorkAddr,
 ) -> FrameArrayType:
     """Fast path shared by direct generation and ``WorkFrameBase.load()``.
 
-    Callers pass only non-zero payload entries. Route is already scalar, so the
-    runtime path only resolves timestamps and packs address fields for those
-    selected entries before expanding payload bytes.
+    Callers pass only non-zero payload entries with already-resolved timestamp
+    values. Route is already scalar, so this only packs address fields before
+    expanding payload bytes.
     """
-    total_ts_width = total_width - axon_width
-    cur_ts = _resolve_work_frame_timestep(
-        tick_relatives, target_lcn, timestep, total_ts_width
-    )
-    frame_base = frame_dest + pack_work_addr(cur_ts, axons, axon_width)
-
-    payload_parts = _payload_to_le_bytes(payload)
-    frame_base = np.repeat(frame_base, payload_parts.shape[1])
-    data_u8 = payload_parts.ravel()
-    return (frame_base + data_u8).astype(FRAME_DTYPE)
+    frame_base = frame_dest + pack_work_addr(resolved_timestep, axons)
+    return _load_work_frame_payload_from_base(frame_base, payload)
 
 
 def _gen_work_frame_bytes(
@@ -442,8 +426,7 @@ def _gen_work_frame_bytes(
     payload: np.ndarray,
     target_lcn: int,
     timestep: int,
-    total_width: int,
-    axon_width: int,
+    timestep_width: int,
     pack_work_addr: PackWorkAddr,
 ) -> FrameArrayType:
     """Generate complete work frames without precomputing a reusable base.
@@ -453,8 +436,6 @@ def _gen_work_frame_bytes(
     """
     payload = _as_1d_payload_array(payload)
     tick, ax = _normalize_work_frame_tick_ax(tick_relatives, axons)
-    total_ts_width = total_width - axon_width
-    _resolve_work_frame_timestep(tick, target_lcn, timestep, total_ts_width)
 
     if payload.size != tick.size:
         raise ValueError(
@@ -462,20 +443,22 @@ def _gen_work_frame_bytes(
             f"{payload.size} != {tick.size}."
         )
 
+    _check_work_frame_tick_relative(tick, target_lcn)
+    timestep_base = _work_frame_timestep_base(target_lcn, timestep, timestep_width)
+
     mask = np.flatnonzero(payload)
     if mask.size == 0:
         return np.array([], dtype=FRAME_DTYPE)
 
     frame_dest = get_frame_dest_v2(header, pkt_offset, pkt_ncopy)
+    resolved_timestep = _resolve_work_frame_timestep_from_base(
+        tick[mask], timestep_base
+    )
     return _load_work_frame_payload(
         frame_dest,
-        tick[mask].astype(FRAME_DTYPE, copy=False),
+        resolved_timestep,
         ax[mask],
         payload[mask],
-        target_lcn,
-        axon_width,
-        timestep,
-        total_width,
         pack_work_addr,
     )
 
@@ -1201,13 +1184,13 @@ class OfflineFrameGenV2(FrameGenV2):
         """Generate weight package for config frame type III."""
         weight = weight.ravel()
         is_compress = csc_compress != CSCAccelerateMode.DISABLE
-        norm_weight_width = _normalize_width_le8(weight_width, name="weight_width")
-        norm_input_width = _normalize_width_le8(input_width, name="input_width")
+        weight_width = _normalize_width_le8(weight_width)
+        input_width = _normalize_width_le8(input_width)
 
         if is_compress:
-            return weight_csc_pack(weight, norm_weight_width, norm_input_width)
+            return weight_csc_pack(weight, weight_width, input_width)
         else:
-            return weight_dense_pack(weight, norm_weight_width)
+            return weight_dense_pack(weight, weight_width)
 
     @staticmethod
     def gen_config_frame4(
@@ -1219,16 +1202,40 @@ class OfflineFrameGenV2(FrameGenV2):
         raise NotImplementedError
 
     @staticmethod
+    def _gen_work_frame(
+        header: FH,
+        F: OfflineWorkFrameFormat,
+        pkt_offset: CoordZXYOffset,
+        pkt_ncopy: AERPacketZXYCopy,
+        tick_relatives: ArrayLike,
+        axons: ArrayLike,
+        target_lcn: int,
+        payload: np.ndarray,
+        timestep: int,
+    ) -> FrameArrayType:
+        return _gen_work_frame_bytes(
+            header,
+            pkt_offset,
+            pkt_ncopy,
+            tick_relatives,
+            axons,
+            payload,
+            target_lcn,
+            timestep,
+            OFFLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_offline_work_addr(ts, ax, F),
+        )
+
+    @staticmethod
     def _gen_work_frame_base(
         header: FH,
-        F: type[Off_Work1_V2 | Off_Work2_V2],
+        F: OfflineWorkFrameFormat,
         pkt_offset: CoordZXYOffset,
         pkt_ncopy: AERPacketZXYCopy,
         tick_relatives: ArrayLike,
         axons: ArrayLike,
         target_lcn: int,
     ) -> FrameArrayType:
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
         return _gen_work_frame_base(
             header,
             pkt_offset,
@@ -1236,9 +1243,8 @@ class OfflineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            17,
-            lambda ts, ax, width: _pack_offline_work_addr(ts, ax, width, F),
+            OFFLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_offline_work_addr(ts, ax, F),
         )
 
     @staticmethod
@@ -1253,21 +1259,17 @@ class OfflineFrameGenV2(FrameGenV2):
         timestep: int = 0,
     ) -> FrameArrayType:
         target_lcn = _normalize_lcn(target_lcn)
-        F = Off_Work1_V2
         payload = np.asarray(data, dtype=PAYLOAD_DATA_DTYPE).ravel()
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
-        return _gen_work_frame_bytes(
+        return OfflineFrameGenV2._gen_work_frame(
             FH.WORK_TYPE1,
+            Off_Work1_V2,
             pkt_offset,
             pkt_ncopy,
             tick_relatives,
             axons,
-            payload,
             target_lcn,
+            payload,
             timestep,
-            17,
-            axon_width,
-            lambda ts, ax, width: _pack_offline_work_addr(ts, ax, width, F),
         )
 
     @staticmethod
@@ -1299,7 +1301,6 @@ class OfflineFrameGenV2(FrameGenV2):
     ) -> OfflineWorkFrame1Base:
         target_lcn = _normalize_lcn(target_lcn)
         F = Off_Work1_V2
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
         frame_dest, tick, ax, base = _make_work_frame_base_parts(
             FH.WORK_TYPE1,
             pkt_offset,
@@ -1307,12 +1308,18 @@ class OfflineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            17,
-            lambda ts, ax, width: _pack_offline_work_addr(ts, ax, width, F),
+            OFFLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_offline_work_addr(ts, ax, F),
         )
         return OfflineWorkFrame1Base(
-            base, frame_dest, tick, ax, target_lcn, 17, axon_width, F
+            base,
+            frame_dest,
+            tick,
+            ax,
+            target_lcn,
+            OFFLINE_WORK_TOTAL_WIDTH,
+            OFFLINE_WORK_AXON_WIDTH,
+            F,
         )
 
     @staticmethod
@@ -1327,21 +1334,17 @@ class OfflineFrameGenV2(FrameGenV2):
         timestep: int = 0,
     ) -> FrameArrayType:
         target_lcn = _normalize_lcn(target_lcn)
-        F = Off_Work2_V2
         voltage = np.asarray(voltage, dtype=VOLTAGE_DTYPE).ravel()
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
-        return _gen_work_frame_bytes(
+        return OfflineFrameGenV2._gen_work_frame(
             FH.WORK_TYPE2,
+            Off_Work2_V2,
             pkt_offset,
             pkt_ncopy,
             tick_relatives,
             axons,
-            voltage,
             target_lcn,
+            voltage,
             timestep,
-            17,
-            axon_width,
-            lambda ts, ax, width: _pack_offline_work_addr(ts, ax, width, F),
         )
 
     @staticmethod
@@ -1373,7 +1376,6 @@ class OfflineFrameGenV2(FrameGenV2):
     ) -> OfflineWorkFrame2Base:
         target_lcn = _normalize_lcn(target_lcn)
         F = Off_Work2_V2
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
         frame_dest, tick, ax, base = _make_work_frame_base_parts(
             FH.WORK_TYPE2,
             pkt_offset,
@@ -1381,12 +1383,18 @@ class OfflineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            17,
-            lambda ts, ax, width: _pack_offline_work_addr(ts, ax, width, F),
+            OFFLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_offline_work_addr(ts, ax, F),
         )
         return OfflineWorkFrame2Base(
-            base, frame_dest, tick, ax, target_lcn, 17, axon_width, F
+            base,
+            frame_dest,
+            tick,
+            ax,
+            target_lcn,
+            OFFLINE_WORK_TOTAL_WIDTH,
+            OFFLINE_WORK_AXON_WIDTH,
+            F,
         )
 
     @staticmethod
@@ -2116,7 +2124,7 @@ class OnlineFrameGenV2(FrameGenV2):
     @staticmethod
     def _gen_work_frame(
         header: FH,
-        F: type[On_Work1_V2 | On_Work2_V2 | On_Work3_V2 | On_Work4_V2],
+        F: OnlineWorkFrameFormat,
         pkt_offset: CoordZXYOffset,
         pkt_ncopy: AERPacketZXYCopy,
         tick_relatives: ArrayLike,
@@ -2125,7 +2133,6 @@ class OnlineFrameGenV2(FrameGenV2):
         payload: np.ndarray,
         timestep: int,
     ) -> FrameArrayType:
-        axon_width = _online_lcn_to_axon_width(target_lcn)
         return _gen_work_frame_bytes(
             header,
             pkt_offset,
@@ -2135,22 +2142,20 @@ class OnlineFrameGenV2(FrameGenV2):
             payload,
             target_lcn,
             timestep,
-            16,
-            axon_width,
-            lambda ts, ax, width: _pack_online_work_addr(ts, ax, width, F),
+            ONLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_online_work_addr(ts, ax, F),
         )
 
     @staticmethod
     def _gen_work_frame_base(
         header: FH,
-        F: type[On_Work1_V2 | On_Work2_V2 | On_Work3_V2 | On_Work4_V2],
+        F: OnlineWorkFrameFormat,
         pkt_offset: CoordZXYOffset,
         pkt_ncopy: AERPacketZXYCopy,
         tick_relatives: ArrayLike,
         axons: ArrayLike,
         target_lcn: int,
     ) -> FrameArrayType:
-        axon_width = _online_lcn_to_axon_width(target_lcn)
         return _gen_work_frame_base(
             header,
             pkt_offset,
@@ -2158,9 +2163,8 @@ class OnlineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            16,
-            lambda ts, ax, width: _pack_online_work_addr(ts, ax, width, F),
+            ONLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_online_work_addr(ts, ax, F),
         )
 
     @staticmethod
@@ -2217,7 +2221,6 @@ class OnlineFrameGenV2(FrameGenV2):
     ) -> OnlineWorkFrame1Base:
         target_lcn = _normalize_lcn(target_lcn)
         F = On_Work1_V2
-        axon_width = _online_lcn_to_axon_width(target_lcn)
         frame_dest, tick, ax, base = _make_work_frame_base_parts(
             FH.WORK_TYPE1,
             pkt_offset,
@@ -2225,12 +2228,18 @@ class OnlineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            16,
-            lambda ts, ax, width: _pack_online_work_addr(ts, ax, width, F),
+            ONLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_online_work_addr(ts, ax, F),
         )
         return OnlineWorkFrame1Base(
-            base, frame_dest, tick, ax, target_lcn, 16, axon_width, F
+            base,
+            frame_dest,
+            tick,
+            ax,
+            target_lcn,
+            ONLINE_WORK_TOTAL_WIDTH,
+            ONLINE_WORK_AXON_WIDTH,
+            F,
         )
 
     @staticmethod
@@ -2287,7 +2296,6 @@ class OnlineFrameGenV2(FrameGenV2):
     ) -> OnlineWorkFrame2Base:
         target_lcn = _normalize_lcn(target_lcn)
         F = On_Work2_V2
-        axon_width = _online_lcn_to_axon_width(target_lcn)
         frame_dest, tick, ax, base = _make_work_frame_base_parts(
             FH.WORK_TYPE2,
             pkt_offset,
@@ -2295,12 +2303,18 @@ class OnlineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            16,
-            lambda ts, ax, width: _pack_online_work_addr(ts, ax, width, F),
+            ONLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_online_work_addr(ts, ax, F),
         )
         return OnlineWorkFrame2Base(
-            base, frame_dest, tick, ax, target_lcn, 16, axon_width, F
+            base,
+            frame_dest,
+            tick,
+            ax,
+            target_lcn,
+            ONLINE_WORK_TOTAL_WIDTH,
+            ONLINE_WORK_AXON_WIDTH,
+            F,
         )
 
     @staticmethod
@@ -2357,7 +2371,6 @@ class OnlineFrameGenV2(FrameGenV2):
     ) -> OnlineWorkFrame3Base:
         target_lcn = _normalize_lcn(target_lcn)
         F = On_Work3_V2
-        axon_width = _online_lcn_to_axon_width(target_lcn)
         frame_dest, tick, ax, base = _make_work_frame_base_parts(
             FH.WORK_TYPE3,
             pkt_offset,
@@ -2365,12 +2378,18 @@ class OnlineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            16,
-            lambda ts, ax, width: _pack_online_work_addr(ts, ax, width, F),
+            ONLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_online_work_addr(ts, ax, F),
         )
         return OnlineWorkFrame3Base(
-            base, frame_dest, tick, ax, target_lcn, 16, axon_width, F
+            base,
+            frame_dest,
+            tick,
+            ax,
+            target_lcn,
+            ONLINE_WORK_TOTAL_WIDTH,
+            ONLINE_WORK_AXON_WIDTH,
+            F,
         )
 
     @staticmethod
@@ -2427,7 +2446,6 @@ class OnlineFrameGenV2(FrameGenV2):
     ) -> OnlineWorkFrame4Base:
         target_lcn = _normalize_lcn(target_lcn)
         F = On_Work4_V2
-        axon_width = _online_lcn_to_axon_width(target_lcn)
         frame_dest, tick, ax, base = _make_work_frame_base_parts(
             FH.WORK_TYPE4,
             pkt_offset,
@@ -2435,12 +2453,18 @@ class OnlineFrameGenV2(FrameGenV2):
             tick_relatives,
             axons,
             target_lcn,
-            axon_width,
-            16,
-            lambda ts, ax, width: _pack_online_work_addr(ts, ax, width, F),
+            ONLINE_WORK_TIMESTEP_WIDTH,
+            lambda ts, ax: _pack_online_work_addr(ts, ax, F),
         )
         return OnlineWorkFrame4Base(
-            base, frame_dest, tick, ax, target_lcn, 16, axon_width, F
+            base,
+            frame_dest,
+            tick,
+            ax,
+            target_lcn,
+            ONLINE_WORK_TOTAL_WIDTH,
+            ONLINE_WORK_AXON_WIDTH,
+            F,
         )
 
     @staticmethod
@@ -2491,46 +2515,68 @@ class OnlineFrameGenV2(FrameGenV2):
 
 def _pad_1d_to_multiple(arr: np.ndarray, multiple: int) -> np.ndarray:
     pad = (-arr.size) % multiple
-    if pad:
+    if pad > 0:
         arr = np.pad(arr, (0, pad), constant_values=0)
     return arr
 
 
-def _pack_u16_groups_to_u64(values: np.ndarray, group_size: int) -> np.ndarray:
+def _pack_u16_groups_to_u64(values: np.ndarray, group_size: int) -> FrameArrayType:
     values = np.ascontiguousarray(values, dtype=np.uint16).ravel()
     values = _pad_1d_to_multiple(values, group_size)
     return values.view(FRAME_DTYPE)
 
 
+@overload
 def _pack_unsigned_groups(
-    values: np.ndarray, bit_width: int, group_size: int, *, out_dtype: np.dtype | type
-) -> np.ndarray:
-    values = np.asarray(values, dtype=out_dtype).reshape(-1, group_size)
-    mask = np.asarray(_mask(bit_width), dtype=out_dtype)
-    shifts = bit_width * np.arange(group_size, dtype=np.uint8)
-    return np.bitwise_or.reduce((values & mask) << shifts, axis=1, dtype=out_dtype)
+    values: np.ndarray, bit_width: int, group_size: int, *, dtype: type[np.uint8]
+) -> NDArray[np.uint8]: ...
 
 
-def _align_sparse_groups(
-    weight_arr: np.ndarray, values: np.ndarray, row_indices: np.ndarray, group_size: int
+@overload
+def _pack_unsigned_groups(
+    values: np.ndarray, bit_width: int, group_size: int, *, dtype: type[np.uint64]
+) -> FrameArrayType: ...
+
+
+def _pack_unsigned_groups(
+    values: np.ndarray,
+    bit_width: int,
+    group_size: int,
+    *,
+    dtype: type[np.uint8] | type[np.uint64],
+) -> NDArray[np.uint8] | FrameArrayType:
+    if dtype not in (np.uint8, FRAME_DTYPE):
+        raise TypeError(f"'dtype' must be np.uint8 or FRAME_DTYPE, got {dtype}.")
+
+    values = np.asarray(values, dtype=dtype).reshape(-1, group_size)
+    mask = np.asarray(_mask(bit_width), dtype=dtype)
+    shifts = bit_width * np.arange(group_size, dtype=dtype)
+    return np.bitwise_or.reduce((values & mask) << shifts, axis=1, dtype=dtype)
+
+
+def _align_sparse_payload_and_indices(
+    payload: np.ndarray, row_indices: np.ndarray, group_size: int
 ) -> tuple[np.ndarray, np.ndarray, int]:
-    n_chunk = math.ceil(row_indices.size / group_size)
-    if row_indices.size == 0:
-        return values, row_indices, n_chunk
+    """Pad one-dimensional CSC payload/index lanes to complete records.
 
-    if (pad := n_chunk * group_size - row_indices.size) == 0:
-        return values, row_indices, n_chunk
+    CSC padding lanes are explicit zero weights. Their stored row index repeats
+    the last real non-zero row index, which preserves nondecreasing index order
+    inside and across emitted records while keeping unpack helpers able to
+    ignore padding by checking the zero payload.
+    """
+    pad = (-row_indices.size) % group_size
+    n_chunk = (row_indices.size + pad) // group_size
+    if pad == 0:
+        return payload, row_indices, n_chunk
 
-    if row_indices.size == weight_arr.size:
-        raise ValueError(
-            f"the sparse weight cannot be aligned in groups of {group_size} "
-            + "because there are all non-zero values."
-        )
+    aligned_size = row_indices.size + pad
+    aligned_payload = np.zeros(aligned_size, dtype=payload.dtype)
+    aligned_payload[: payload.size] = payload
 
-    idx_first_zero = int(np.flatnonzero(weight_arr == 0)[0])
-    values = np.pad(values, (0, pad), constant_values=0)
-    row_indices = np.pad(row_indices, (0, pad), constant_values=idx_first_zero)
-    return values, row_indices, n_chunk
+    aligned_indices = np.empty(aligned_size, dtype=row_indices.dtype)
+    aligned_indices[: row_indices.size] = row_indices
+    aligned_indices[row_indices.size :] = row_indices[-1]
+    return aligned_payload, aligned_indices, n_chunk
 
 
 def weight_dense_pack(weight: np.ndarray, weight_width: DataWidthLE8) -> FrameArrayType:
@@ -2550,7 +2596,7 @@ def weight_dense_pack(weight: np.ndarray, weight_width: DataWidthLE8) -> FrameAr
     weights_per_byte = 8 // weight_width
     # Reduce to u8 (N,) and then view 8*u8 as u64.
     reduced = _pack_unsigned_groups(
-        weight, weight_width, weights_per_byte, out_dtype=np.uint8
+        weight, weight_width, weights_per_byte, dtype=np.uint8
     )
     return reduced.view(FRAME_DTYPE)
 
@@ -2564,45 +2610,50 @@ def weight_csc_pack(
     1-bit           [127:16]        [ 6:0] stored 7 non-zero 1-bit weights
     2-bit           [127:16]        [13:0] stored 7 non-zero 2-bit weights
     4-bit           [127:32]        [23:0] stored 6 non-zero 4-bit weights
-    8-bit           [127:32]        [39:0] stored 5 non-zero 8-bit weights
+    8-bit           [127:48]        [39:0] stored 5 non-zero 8-bit weights
 
-    NOTE: Non-zero values must be aligned in groups of 7/7/6/5. If all the values of a sparse weight    \
-        are non-zero but need alignment, an exception will raise. If there is any 0, the first index    \
-        pointing to 0 will be used as padding.
+    NOTE: Non-zero values are aligned in groups of 7/7/6/5. Padding lanes store
+        zero payloads, and their indices repeat the last real non-zero index to
+        preserve monotonically nondecreasing CSC indices.
     """
     weight = np.asarray(weight, dtype=np.uint8).ravel()
     # #N of non-zero weight stored in a single address of RAM
     N_NONZERO_WEIGHT_PER_ADDR = {1: 7, 2: 7, 4: 6, 8: 5}
     INDICES_ADDR_OFFSET = {1: 16, 2: 16, 4: 32, 8: 48}
+    n_nonzero_w_per_addr = N_NONZERO_WEIGHT_PER_ADDR[weight_width]
 
-    row_indices = np.flatnonzero(weight)
+    row_indices = np.flatnonzero(weight)  # idx of non-zero weight
     if row_indices.size == 0:
         return np.array([], dtype=FRAME_DTYPE)
 
-    w_nonzero = weight[row_indices]
-
-    n_nonzero_w_per_addr = N_NONZERO_WEIGHT_PER_ADDR[weight_width]
-    w_nonzero, row_indices, n_chunk = _align_sparse_groups(
-        weight, w_nonzero, row_indices, n_nonzero_w_per_addr
+    w_payload, row_indices, n_chunk = _align_sparse_payload_and_indices(
+        weight[row_indices], row_indices, n_nonzero_w_per_addr
     )
 
-    # in csc pack, the indice stored in RAM is the bit offset of the non-zero weight,
+    # In csc pack, the indice stored in RAM is the bit offset of the non-zero weight,
     # which is the original index multiplied by input_width.
-    row_indices = row_indices * input_width
+    row_indices *= input_width
+    # Hardware CSC `weight_indice` fields are 16-bit values.
+    if row_indices.max() > CSC_WEIGHT_INDEX_MAX:
+        raise ValueError(
+            "CSC weight indices are stored in 16-bit fields; "
+            f"got max bit index {row_indices.max()}."
+        )
+
     w_reduced_chunk = _pack_unsigned_groups(
-        w_nonzero, weight_width, n_nonzero_w_per_addr, out_dtype=FRAME_DTYPE
+        w_payload, weight_width, n_nonzero_w_per_addr, dtype=FRAME_DTYPE
     )
 
     n_idx_at_high = 4  # 4 indices will placed at high [127:64]
     n_idx_at_low = n_nonzero_w_per_addr - n_idx_at_high
     idx_chunks = row_indices.reshape(n_chunk, n_nonzero_w_per_addr).astype(np.uint16)
     idx_reduced_chunk_h = _pack_unsigned_groups(
-        idx_chunks[:, n_idx_at_low:], 16, n_idx_at_high, out_dtype=FRAME_DTYPE
+        idx_chunks[:, n_idx_at_low:], 16, n_idx_at_high, dtype=FRAME_DTYPE
     )
     idx_reduced_chunk_l = _pack_unsigned_groups(
-        idx_chunks[:, :n_idx_at_low], 16, n_idx_at_low, out_dtype=FRAME_DTYPE
+        idx_chunks[:, :n_idx_at_low], 16, n_idx_at_low, dtype=FRAME_DTYPE
     )
-    idx_reduced_chunk_l = idx_reduced_chunk_l << INDICES_ADDR_OFFSET[weight_width]
+    idx_reduced_chunk_l <<= INDICES_ADDR_OFFSET[weight_width]
 
     result = np.zeros((2 * n_chunk,), dtype=FRAME_DTYPE)
     # Little endian
@@ -2623,22 +2674,24 @@ def online_weight_csc_pack(weight: np.ndarray) -> FrameArrayType:
     corresponding 16-bit row indices in ``[127:64]``. The result is returned as
     an ``(n,)`` ``u64`` array, so each record becomes two adjacent 64-bit words.
     """
-    weight_arr = weight.ravel()
-    row_indices = np.flatnonzero(weight_arr)
+    weight = weight.ravel()
+    N_NONZERO_W_PER_ADDR = 4
+
+    row_indices = np.flatnonzero(weight)
     if row_indices.size == 0:
         return np.array([], dtype=FRAME_DTYPE)
 
     # Keep only the non-zero BF16 payloads; CSC stores weights and indices in
     # parallel 4-lane groups.
-    w_nonzero = pack_bf16_payload_bits(weight_arr).ravel()[row_indices]
-    n_nonzero_w_per_addr = 4
-    w_nonzero, row_indices, n_chunk = _align_sparse_groups(
-        weight_arr, w_nonzero, row_indices, n_nonzero_w_per_addr
+    w_payload, row_indices, n_chunk = _align_sparse_payload_and_indices(
+        pack_bf16_payload_bits(weight).ravel()[row_indices],
+        row_indices,
+        N_NONZERO_W_PER_ADDR,
     )
 
     result = np.zeros((2 * n_chunk,), dtype=FRAME_DTYPE)
     # A single 128-bit CSC record is emitted as two adjacent u64 words:
     # low 64 bits for 4 BF16 weights, high 64 bits for 4 uint16 row indices.
-    result[0::2] = _pack_u16_groups_to_u64(w_nonzero, n_nonzero_w_per_addr)
-    result[1::2] = _pack_u16_groups_to_u64(row_indices, n_nonzero_w_per_addr)
+    result[0::2] = _pack_u16_groups_to_u64(w_payload, N_NONZERO_W_PER_ADDR)
+    result[1::2] = _pack_u16_groups_to_u64(row_indices, N_NONZERO_W_PER_ADDR)
     return result

--- a/tests/framelib/test_frame_gen_v2.py
+++ b/tests/framelib/test_frame_gen_v2.py
@@ -1,6 +1,5 @@
-import contextlib
 import math
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import numpy as np
 import pytest
@@ -43,6 +42,7 @@ from paicorelib.framelib.frame_defs import OnlineWorkFrame2FormatV2 as On_Work2_
 from paicorelib.framelib.frame_defs import OnlineWorkFrame3FormatV2 as On_Work3_V2
 from paicorelib.framelib.frame_defs import OnlineWorkFrame4FormatV2 as On_Work4_V2
 from paicorelib.framelib.frame_gen_v2 import (
+    DataWidthLE8,
     DataWidthLE8Like,
     FrameGenV2,
     OfflineFrameGenV2,
@@ -149,9 +149,11 @@ def extract_online_lut_from_cf2(cf2: FrameArrayType):
     return arr_pot, arr_act_bits
 
 
-def normalize_width_bits(value: DataWidthLE8Like) -> WidthBitsLE8:
-    width_bits = (1 << value.value) if isinstance(value, DataWidth) else int(value)
-    return cast(WidthBitsLE8, width_bits)
+def normalize_width_bits(width: DataWidthLE8Like) -> DataWidthLE8:
+    width_bits = (1 << width.value) if isinstance(width, DataWidth) else int(width)
+    if width_bits not in (1, 2, 4, 8):
+        raise ValueError(f"only supports 1/2/4/8-bit widths, got {width}.")
+    return width_bits
 
 
 def gen_v2_weight_array(
@@ -191,14 +193,6 @@ def _target_lcn_index(target_lcn: LCN_EX | int) -> int:
     return target_lcn.value if isinstance(target_lcn, LCN_EX) else target_lcn
 
 
-def _offline_lcn_to_axon_width(target_lcn: LCN_EX | int) -> int:
-    return 9 + _target_lcn_index(target_lcn)
-
-
-def _online_lcn_to_axon_width(target_lcn: LCN_EX | int) -> int:
-    return 8 + _target_lcn_index(target_lcn)
-
-
 def _compose_work_ts_ax_addr(tick_relatives, axons, axon_width: int, total_width: int):
     ts_width = total_width - axon_width
     ts = np.asarray(tick_relatives, dtype=FRAME_DTYPE).ravel()
@@ -223,9 +217,7 @@ def _offline_work_ts_ax_addr(
     timestep: int = 0,
 ) -> FrameArrayType:
     cur_ts = _resolve_work_frame_timestep(tick_relatives, target_lcn, timestep)
-    ts_ax_addr = _compose_work_ts_ax_addr(
-        cur_ts, axons, _offline_lcn_to_axon_width(target_lcn), 17
-    )
+    ts_ax_addr = _compose_work_ts_ax_addr(cur_ts, axons, 9, 17)
     return (
         ((ts_ax_addr >> 16) << F.TIMESTEP_HIGH7_OFFSET)
         | ((ts_ax_addr & _mask(16)) << F.AXON_ADDR_OFFSET)
@@ -242,12 +234,7 @@ def _online_work_ts_ax_addr(
 ) -> FrameArrayType:
     cur_ts = _resolve_work_frame_timestep(tick_relatives, target_lcn, timestep)
     return (
-        (
-            _compose_work_ts_ax_addr(
-                cur_ts, axons, _online_lcn_to_axon_width(target_lcn), 16
-            )
-            & F.TIMESTEP_AXON_MASK
-        )
+        (_compose_work_ts_ax_addr(cur_ts, axons, 8, 16) & F.TIMESTEP_AXON_MASK)
         << F.TIMESTEP_AXON_OFFSET
     ).astype(FRAME_DTYPE, copy=False)
 
@@ -391,7 +378,11 @@ def weight_dense_unpack(
 
 
 def weight_csc_unpack(
-    frames: FrameArrayType, weight_width: int, signed: bool, original_size: int
+    frames: FrameArrayType,
+    weight_width: int,
+    signed: bool,
+    original_size: int,
+    input_width: int = 1,
 ) -> NDArray[np.int8 | np.uint8]:
     n_nonzero_w_per_addr = {1: 7, 2: 7, 4: 6, 8: 5}[weight_width]
     indices_addr_offset = {1: 16, 2: 16, 4: 32, 8: 48}[weight_width]
@@ -416,11 +407,39 @@ def weight_csc_unpack(
         chunk_high64, 16, n_idx_at_high, dtype=np.uint16
     )
     indices = np.hstack([indices_l, indices_h])
+    if input_width != 1:
+        indices = indices // input_width
     weights = _restore_signed_weights(weights, weight_width, signed)
 
     result = np.zeros(original_size, dtype=weights.dtype)
-    result[indices] = weights
+    payload_mask = weights != 0
+    result[indices[payload_mask]] = weights[payload_mask]
     return result
+
+
+def csc_index_fields(frames: FrameArrayType, weight_width: int) -> NDArray[np.uint16]:
+    n_nonzero_w_per_addr = {1: 7, 2: 7, 4: 6, 8: 5}[weight_width]
+    indices_addr_offset = {1: 16, 2: 16, 4: 32, 8: 48}[weight_width]
+
+    chunk_low64 = frames[0::2]
+    chunk_high64 = frames[1::2]
+    n_idx_at_high = 4
+    n_idx_at_low = n_nonzero_w_per_addr - n_idx_at_high
+    indices_l = _unpack_unsigned_groups(
+        chunk_low64 >> indices_addr_offset, 16, n_idx_at_low, dtype=np.uint16
+    )
+    indices_h = _unpack_unsigned_groups(
+        chunk_high64, 16, n_idx_at_high, dtype=np.uint16
+    )
+    return np.hstack([indices_l, indices_h]).ravel()
+
+
+def csc_payload_fields(frames: FrameArrayType, weight_width: int) -> NDArray[np.uint8]:
+    n_nonzero_w_per_addr = {1: 7, 2: 7, 4: 6, 8: 5}[weight_width]
+
+    return _unpack_unsigned_groups(
+        frames[0::2], weight_width, n_nonzero_w_per_addr, dtype=np.uint8
+    ).ravel()
 
 
 def online_weight_dense_unpack(
@@ -443,8 +462,42 @@ def online_weight_csc_unpack(
     indices = index_chunks.reshape(-1, 4)
 
     result = np.zeros(original_size, dtype=np.uint16)
-    result[indices] = weights
+    payload_mask = weights != 0
+    result[indices[payload_mask]] = weights[payload_mask]
     return result
+
+
+def pack_u16_lanes_for_test(values: list[int] | NDArray[np.uint16]) -> FRAME_DTYPE:
+    lanes = np.asarray(values, dtype=FRAME_DTYPE)
+    shifts = 16 * np.arange(lanes.size, dtype=FRAME_DTYPE)
+    return np.bitwise_or.reduce(lanes << shifts, dtype=FRAME_DTYPE)
+
+
+def pack_offline_csc_8bit_record_for_test(
+    payload: list[int], indices: list[int]
+) -> FrameArrayType:
+    assert len(payload) == 5
+    assert len(indices) == 5
+
+    payload_word = np.asarray(payload, dtype=FRAME_DTYPE)
+    payload_shifts = 8 * np.arange(5, dtype=FRAME_DTYPE)
+    low_payload = np.bitwise_or.reduce(
+        payload_word << payload_shifts, dtype=FRAME_DTYPE
+    )
+    low_indices = pack_u16_lanes_for_test(indices[:1]) << 48
+    high_indices = pack_u16_lanes_for_test(indices[1:])
+    return np.array([low_payload | low_indices, high_indices], dtype=FRAME_DTYPE)
+
+
+def pack_online_csc_record_for_test(
+    payload: list[float] | NDArray[np.floating], indices: list[int]
+) -> FrameArrayType:
+    assert len(indices) == 4
+    payload_bits = pack_bf16_payload_bits(payload)
+    return np.array(
+        [pack_u16_lanes_for_test(payload_bits), pack_u16_lanes_for_test(indices)],
+        dtype=FRAME_DTYPE,
+    )
 
 
 class TestFrameGenV2:
@@ -962,10 +1015,12 @@ class TestOfflineFrameGenV2:
     @pytest.mark.parametrize(
         "weight_width, input_width, csc_compress",
         [
-            (8, 8, False),
-            (DataWidth.WIDTH_4BIT, DataWidth.WIDTH_2BIT, False),
+            (8, DataWidth.WIDTH_8BIT, False),
+            (DataWidth.WIDTH_4BIT, DataWidth.WIDTH_8BIT, False),
             (DataWidth.WIDTH_8BIT, DataWidth.WIDTH_1BIT, CSCAccelerateMode.ENABLE),
+            (DataWidth.WIDTH_8BIT, DataWidth.WIDTH_8BIT, CSCAccelerateMode.ENABLE),
         ],
+        ids=["dense-int", "dense-enum", "sparse-uint1-input", "sparse-uint8-input"],
     )
     def test_gen_config_frame3_weight_pkg(
         self,
@@ -987,12 +1042,25 @@ class TestOfflineFrameGenV2:
         )
 
         if is_sparse:
-            input_bits = normalize_width_bits(input_width)
-            expected = weight_csc_pack(weight, width_bits, input_bits)
+            expected = weight_csc_pack(
+                weight, width_bits, normalize_width_bits(input_width)
+            )
         else:
             expected = weight_dense_pack(weight, width_bits)
 
         assert np.array_equal(result, expected)
+
+    def test_gen_config_frame3_weight_pkg_uint8_csc_writes_bit_indices(self):
+        weight = np.array([1, 0, 2, 0, 3], dtype=np.uint8)
+
+        result = OfflineFrameGenV2.gen_config_frame3_weight_pkg(
+            weight,
+            DataWidth.WIDTH_8BIT,
+            DataWidth.WIDTH_8BIT,
+            CSCAccelerateMode.ENABLE,
+        )
+
+        assert csc_index_fields(result, 8)[:3].tolist() == [0, 16, 32]
 
     @pytest.mark.parametrize(
         "weight_width, input_width",
@@ -1047,7 +1115,7 @@ class TestOfflineFrameGenV2:
         )
         ts0 = _resolve_work_frame_timestep(tick0, target_lcn, timestep)[0]
         axon0 = axon[0] if isinstance(axon, np.ndarray) else axon
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
+        axon_width = 9
         ts_width = 17 - axon_width
         ts_ax_addr0 = _compose_work_ts_ax_addr(ts0, axon0, axon_width, 17)[0]
 
@@ -1081,6 +1149,19 @@ class TestOfflineFrameGenV2:
         assert wf1.shape == (2,)
         assert bit_field(wf1[0], Off_Work1_V2.DATA_OFFSET, Off_Work1_V2.DATA_MASK) == 5
         assert bit_field(wf1[1], Off_Work1_V2.DATA_OFFSET, Off_Work1_V2.DATA_MASK) == 6
+
+    def test_wf1_tick_relative_packs_above_physical_axon_field(self):
+        wf1 = OfflineFrameGenV2.gen_work_frame1(
+            CoordZXYOffset(1, 0, 4),
+            AERPacketZXYCopy(0, 0, 0),
+            tick_relatives=[1],
+            axons=[0],
+            target_lcn=LCN_EX.LCN_4X,
+            data=np.array([0x40], dtype=np.uint8),
+            timestep=0,
+        )
+
+        assert wf1.tolist() == [0x8040100000020040]
 
     def test_wf1_flattens_payload_before_filtering(self, v2_packet_route):
         pkt_offset, pkt_ncopy = v2_packet_route
@@ -1121,10 +1202,9 @@ class TestOfflineFrameGenV2:
         target_lcn = LCN_EX.LCN_4X
         n = 512
 
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
         tick_limit = 1 << _target_lcn_index(target_lcn)
         tick_relatives = (np.arange(n, dtype=np.uint32) * 3 + 1) % tick_limit
-        axons = (np.arange(n, dtype=np.uint32) * 7 + 11) & _mask(axon_width)
+        axons = (np.arange(n, dtype=np.uint32) * 7 + 11) & _mask(9)
         timestep = 7
 
         data = gen_random_array((n,), data_dtype, sparse_ratio=1 / 6)
@@ -1202,7 +1282,7 @@ class TestOfflineFrameGenV2:
         target_lcn = LCN_EX.LCN_8X.value
         n = 384
 
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
+        axon_width = 9
         tick_limit = 1 << _target_lcn_index(target_lcn)
         tick_relatives = (np.arange(n, dtype=np.uint32) * 5 + 1) % tick_limit
         axons = (np.arange(n, dtype=np.uint32) * 9 + 3) & _mask(axon_width)
@@ -1267,6 +1347,122 @@ class TestOfflineFrameGenV2:
         assert wf2.size == 0
 
     @pytest.mark.parametrize(
+        "tick_relatives,axons,data,err_match",
+        [
+            (np.array([0, 1]), np.array([5]), np.ones(2, dtype=np.uint8), "axons"),
+            (
+                np.array([0, 0]),
+                np.array([5, 6]),
+                np.ones(1, dtype=np.uint8),
+                "payload",
+            ),
+        ],
+        ids=["axon-size", "payload-size"],
+    )
+    def test_work_frame_rejects_mismatched_lengths(
+        self, v2_packet_route, tick_relatives, axons, data, err_match
+    ):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        with pytest.raises(ValueError, match=err_match):
+            OfflineFrameGenV2.gen_work_frame1(
+                pkt_offset, pkt_ncopy, tick_relatives, axons, LCN_EX.LCN_1X, data
+            )
+
+    @pytest.mark.parametrize(
+        "kwargs,err_type,err_match",
+        [
+            ({"target_lcn": -1}, ValueError, "target_lcn"),
+            ({"target_lcn": LCN_EX.LCN_128X + 1}, ValueError, "target_lcn"),
+            ({"timestep": -1}, ValueError, "non-negative"),
+            ({"timestep": 1.5}, TypeError, "unsupported operand"),
+            (
+                {"tick_relatives": np.array([-1]), "target_lcn": LCN_EX.LCN_2X},
+                ValueError,
+                "non-negative",
+            ),
+            (
+                {"tick_relatives": np.array([2]), "target_lcn": LCN_EX.LCN_2X},
+                ValueError,
+                r"range \[0, 2\)",
+            ),
+            (
+                {
+                    "tick_relatives": np.array([0, 2], dtype=np.uint32),
+                    "target_lcn": LCN_EX.LCN_2X,
+                    "data": np.zeros(2, dtype=np.uint8),
+                },
+                ValueError,
+                r"range \[0, 2\)",
+            ),
+            (
+                {"tick_relatives": np.array([0]), "target_lcn": LCN_EX.LCN_1X},
+                ValueError,
+                "resolved timestep",
+            ),
+            (
+                {
+                    "tick_relatives": np.array([0]),
+                    "target_lcn": LCN_EX.LCN_8X,
+                    "timestep": 32,
+                },
+                ValueError,
+                "resolved timestep",
+            ),
+            (
+                {
+                    "target_lcn": LCN_EX.LCN_1X,
+                    "data": np.zeros(2, dtype=np.uint8),
+                    "use_static": True,
+                },
+                ValueError,
+                "resolved timestep",
+            ),
+        ],
+        ids=[
+            "negative-lcn",
+            "too-large-lcn",
+            "negative-timestep",
+            "non-int-timestep",
+            "negative-tick-relative",
+            "tick-relative-out-of-range",
+            "zero-payload-tick-relative-out-of-range",
+            "timestep-base-overflow",
+            "shifted-timestep-overflow",
+            "zero-payload-static-timestep-overflow",
+        ],
+    )
+    def test_work_frame_rejects_invalid_timing_or_lcn(
+        self, v2_packet_route, kwargs, err_type, err_match
+    ):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        tick_relatives = kwargs.get("tick_relatives", np.array([0]))
+        target_lcn = kwargs.get("target_lcn", LCN_EX.LCN_1X)
+        timestep = kwargs.get("timestep", 256)
+        data = kwargs.get("data", np.array([1], dtype=np.uint8))
+
+        with pytest.raises(err_type, match=err_match):
+            if kwargs.get("use_static", False):
+                static = OfflineFrameGenV2.gen_work_frame1_static(
+                    pkt_offset,
+                    pkt_ncopy,
+                    np.zeros(data.size, dtype=np.uint32),
+                    np.arange(data.size, dtype=np.uint32) + 5,
+                    target_lcn,
+                )
+                static.load(data, timestep=timestep)
+            else:
+                axons = np.arange(np.asarray(data).size, dtype=np.uint32) + 5
+                OfflineFrameGenV2.gen_work_frame1(
+                    pkt_offset,
+                    pkt_ncopy,
+                    tick_relatives,
+                    axons,
+                    target_lcn,
+                    data,
+                    timestep=timestep,
+                )
+
+    @pytest.mark.parametrize(
         "method_name,data,target_lcn,timestep",
         [
             (
@@ -1295,7 +1491,7 @@ class TestOfflineFrameGenV2:
         self, v2_packet_route, method_name, data, target_lcn, timestep
     ):
         pkt_offset, pkt_ncopy = v2_packet_route
-        axon_width = _offline_lcn_to_axon_width(target_lcn)
+        axon_width = 9
         tick_limit = 1 << _target_lcn_index(target_lcn)
         tick_relatives = (np.arange(data.size, dtype=np.uint32) + 1) % tick_limit
         axons = (np.arange(data.size, dtype=np.uint32) * 7 + 10) & _mask(axon_width)
@@ -1321,6 +1517,36 @@ class TestOfflineFrameGenV2:
         assert type(static.target_lcn) is int
         assert static.target_lcn == _target_lcn_index(target_lcn)
         assert np.array_equal(static.load(data, timestep=timestep), direct)
+
+    def test_work_frame_static_load_timestep_zero_uses_base_layout(
+        self, v2_packet_route
+    ):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        tick_relatives = np.array([0, 1, 0], dtype=np.uint32)
+        axons = np.array([5, 6, 7], dtype=np.uint32)
+        data = np.array([0x11223344, 0, -2], dtype=np.int32)
+        static = OfflineFrameGenV2.gen_work_frame2_static(
+            pkt_offset, pkt_ncopy, tick_relatives, axons, LCN_EX.LCN_2X
+        )
+
+        loaded = static.load(data, timestep=0)
+        direct = OfflineFrameGenV2.gen_work_frame2(
+            pkt_offset,
+            pkt_ncopy,
+            tick_relatives,
+            axons,
+            LCN_EX.LCN_2X,
+            data,
+            timestep=0,
+        )
+        payload_rows = _payload_le_byte_rows(data[np.flatnonzero(data)])
+        expected = (
+            np.repeat(static.base[np.flatnonzero(data)], payload_rows.shape[1])
+            + payload_rows.ravel()
+        ).astype(FRAME_DTYPE)
+
+        assert np.array_equal(loaded, direct)
+        assert np.array_equal(loaded, expected)
 
     def test_control_frames(self, v2_packet_route):
         pkt_offset, pkt_ncopy = v2_packet_route
@@ -1913,61 +2139,10 @@ class TestOnlineFrameGenV2:
             weight, CSCAccelerateMode.ENABLE
         )
 
-        packed_weights = np.ascontiguousarray(
-            pack_bf16_payload_bits([1.0, -2.0, 3.25, 0.0]), dtype=np.dtype("<u2")
-        ).view(FRAME_DTYPE)
-        packed_indices = np.ascontiguousarray(
-            np.array([1, 3, 4, 0], dtype=np.dtype("<u2"))
-        ).view(FRAME_DTYPE)
-        expected = np.array([packed_weights[0], packed_indices[0]], dtype=FRAME_DTYPE)
+        expected = pack_online_csc_record_for_test([1.0, -2.0, 3.25, 0.0], [1, 3, 4, 4])
 
         assert result.shape == (2,)
         assert np.array_equal(result, expected)
-
-    def test_online_weight_csc_pack_rejects_all_nonzero_unaligned(self):
-        weight = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float16)
-        with pytest.raises(ValueError, match="groups of 4"):
-            OnlineFrameGenV2.gen_config_frame3_weight_pkg(
-                weight, CSCAccelerateMode.ENABLE
-            )
-
-    @pytest.mark.parametrize("float_dtype", [np.float16, np.float32, np.float64])
-    def test_online_weight_dense_pack_8_bf16_weights(self, float_dtype):
-        weight = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=float_dtype)
-        result = online_weight_dense_pack(weight)
-        expected_bits = pack_bf16_payload_bits(weight).astype(FRAME_DTYPE, copy=False)
-        shifts = 16 * np.arange(4, dtype=FRAME_DTYPE)
-        expected = np.array(
-            [
-                np.bitwise_or.reduce(expected_bits[:4] << shifts, dtype=FRAME_DTYPE),
-                np.bitwise_or.reduce(expected_bits[4:] << shifts, dtype=FRAME_DTYPE),
-            ],
-            dtype=FRAME_DTYPE,
-        )
-
-        assert result.shape == (2,)
-        assert np.array_equal(result, expected)
-
-    @pytest.mark.parametrize("float_dtype", [np.float16, np.float32, np.float64])
-    def test_online_weight_dense_unpack(self, float_dtype):
-        rng = np.random.default_rng(20260428)
-        weight = rng.uniform(-8.0, 8.0, 77).astype(float_dtype)
-        mapped = online_weight_dense_pack(weight)
-
-        unpacked = online_weight_dense_unpack(mapped, weight.size)
-        assert unpacked.dtype == np.uint16
-        assert np.array_equal(unpacked, pack_bf16_payload_bits(weight).ravel())
-
-    @pytest.mark.parametrize("float_dtype", [np.float16, np.float32, np.float64])
-    def test_online_weight_csc_unpack(self, float_dtype):
-        rng = np.random.default_rng(20260428)
-        weight = rng.uniform(-8.0, 8.0, 77).astype(float_dtype)
-        weight[rng.choice(weight.size, size=weight.size // 4, replace=False)] = 0
-        mapped = online_weight_csc_pack(weight)
-
-        unpacked = online_weight_csc_unpack(mapped, weight.size)
-        assert unpacked.dtype == np.uint16
-        assert np.array_equal(unpacked, pack_bf16_payload_bits(weight).ravel())
 
     def test_cf4(self, v2_packet_route):
         pkt_offset, pkt_ncopy = v2_packet_route
@@ -2004,7 +2179,7 @@ class TestOnlineFrameGenV2:
     ):
         pkt_offset, pkt_ncopy = v2_packet_route
         n = data.size
-        axon_width = _online_lcn_to_axon_width(target_lcn)
+        axon_width = 8
         tick_limit = 1 << _target_lcn_index(target_lcn)
         tick_relatives = (np.arange(n, dtype=np.uint32) * 5 + 3) % tick_limit
         axons = (np.arange(n, dtype=np.uint32) * 11 + 7) & _mask(axon_width)
@@ -2048,6 +2223,27 @@ class TestOnlineFrameGenV2:
         )
         assert wf.size == np.count_nonzero(data) * data.dtype.itemsize
         assert np.any(data == 0)
+
+    def test_wf1_tick_relative_packs_above_physical_axon_field(self):
+        wf1 = OnlineFrameGenV2.gen_work_frame1(
+            CoordZXYOffset(1, 0, 4),
+            AERPacketZXYCopy(0, 0, 0),
+            tick_relatives=[1],
+            axons=[0],
+            target_lcn=LCN_EX.LCN_4X,
+            data=np.array([1], dtype=np.uint8),
+            timestep=0,
+        )
+
+        assert wf1.tolist() == [0x8040100000010001]
+        assert (
+            bit_field(wf1[0], On_Work1_V2.AXON_ADDR_OFFSET, On_Work1_V2.AXON_ADDR_MASK)
+            == 0
+        )
+        assert (
+            bit_field(wf1[0], On_Work1_V2.TIMESTEP_OFFSET, On_Work1_V2.TIMESTEP_MASK)
+            == 1
+        )
 
     @pytest.mark.parametrize(
         "method_name,target_lcn,data,timestep",
@@ -2104,7 +2300,7 @@ class TestOnlineFrameGenV2:
         self, v2_packet_route, method_name, target_lcn, data, timestep
     ):
         pkt_offset, pkt_ncopy = v2_packet_route
-        axon_width = _online_lcn_to_axon_width(target_lcn)
+        axon_width = 8
         tick_limit = 1 << _target_lcn_index(target_lcn)
         tick_relatives = (np.arange(data.size, dtype=np.uint32) + 1) % tick_limit
         axons = (np.arange(data.size, dtype=np.uint32) * 11 + 5) & _mask(axon_width)
@@ -2130,6 +2326,36 @@ class TestOnlineFrameGenV2:
         assert type(static.target_lcn) is int
         assert static.target_lcn == _target_lcn_index(target_lcn)
         assert np.array_equal(static.load(data, timestep=timestep), direct)
+
+    def test_work_frame_static_load_timestep_zero_uses_base_layout(
+        self, v2_packet_route
+    ):
+        pkt_offset, pkt_ncopy = v2_packet_route
+        tick_relatives = np.array([0, 1, 0], dtype=np.uint32)
+        axons = np.array([5, 6, 7], dtype=np.uint32)
+        data = np.array([1.5, 0.0, -2.0], dtype=np.float16)
+        static = OnlineFrameGenV2.gen_work_frame2_static(
+            pkt_offset, pkt_ncopy, tick_relatives, axons, LCN_EX.LCN_2X
+        )
+
+        loaded = static.load(data, timestep=0)
+        direct = OnlineFrameGenV2.gen_work_frame2(
+            pkt_offset,
+            pkt_ncopy,
+            tick_relatives,
+            axons,
+            LCN_EX.LCN_2X,
+            data,
+            timestep=0,
+        )
+        payload_rows = _payload_le_byte_rows(data[np.flatnonzero(data)])
+        expected = (
+            np.repeat(static.base[np.flatnonzero(data)], payload_rows.shape[1])
+            + payload_rows.ravel()
+        ).astype(FRAME_DTYPE)
+
+        assert np.array_equal(loaded, direct)
+        assert np.array_equal(loaded, expected)
 
     def test_work_frame_static_load_rejects_payload_size_mismatch(
         self, v2_packet_route
@@ -2335,7 +2561,7 @@ class TestOnlineFrameGenV2:
                 {
                     "tick_relatives": np.array([0]),
                     "target_lcn": LCN_EX.LCN_8X,
-                    "timestep": 4,
+                    "timestep": 32,
                 },
                 ValueError,
                 "resolved timestep",
@@ -2346,7 +2572,7 @@ class TestOnlineFrameGenV2:
             "non-int-timestep",
             "negative-tick-relative",
             "tick-relative-out-of-range",
-            "resolved-timestep-overflow",
+            "timestep-base-overflow",
             "shifted-timestep-overflow",
         ],
     )
@@ -2367,18 +2593,6 @@ class TestOnlineFrameGenV2:
                 target_lcn,
                 np.array([1.5], dtype=np.float16),
                 timestep=timestep,
-            )
-
-    def test_work_frame_rejects_old_timesteps_keyword(self, v2_packet_route):
-        pkt_offset, pkt_ncopy = v2_packet_route
-        with pytest.raises(TypeError, match="timesteps"):
-            OnlineFrameGenV2.gen_work_frame2(
-                pkt_offset,
-                pkt_ncopy,
-                axons=np.array([5]),
-                target_lcn=LCN_EX.LCN_1X,
-                gradient=np.array([1.5], dtype=np.float16),
-                timesteps=np.array([0]),
             )
 
     def test_work_frame_payload_scalar_is_single_item(self, v2_packet_route):
@@ -2513,110 +2727,309 @@ class TestOnlineFrameGenV2:
         )
 
 
-@pytest.mark.parametrize(
-    "size, weight_width, signed",
-    [
-        (100, 8, True),
-        (128, 8, False),
-        (100, 4, True),
-        (64, 4, False),
-        (60, 2, True),
-        (200, 1, True),
-        (256, 1, False),
-        (0, 8, True),
-        (0, 8, False),
-    ],
-)
-def test_weight_uncompressed_unpack(size, weight_width, signed, fixed_rng):
-    weight = gen_v2_weight_array(size, weight_width, signed, fixed_rng)
-    mapped = weight_dense_pack(weight, weight_width)
-
-    align_size = 128 // weight_width
-    expected_size = math.ceil(weight.size / align_size) * (
-        128 // (FRAME_DTYPE(0).nbytes * 8)
+class TestOfflineWeightPackV2:
+    @pytest.mark.parametrize(
+        "size, weight_width, signed",
+        [
+            (100, 8, True),
+            (128, 8, False),
+            (100, 4, True),
+            (64, 4, False),
+            (60, 2, True),
+            (200, 1, True),
+            (256, 1, False),
+            (0, 8, True),
+            (0, 8, False),
+        ],
     )
+    def test_weight_uncompressed_unpack(self, size, weight_width, signed, fixed_rng):
+        weight = gen_v2_weight_array(size, weight_width, signed, fixed_rng)
+        mapped = weight_dense_pack(weight, weight_width)
 
-    assert mapped.dtype == FRAME_DTYPE
-    assert mapped.shape == (expected_size,)
+        align_size = 128 // weight_width
+        expected_size = math.ceil(weight.size / align_size) * (
+            128 // (FRAME_DTYPE(0).nbytes * 8)
+        )
 
-    unmapped = weight_dense_unpack(mapped, weight_width, signed, size)
-    assert unmapped.dtype == weight.dtype
-    assert np.array_equal(weight, unmapped)
+        assert mapped.dtype == FRAME_DTYPE
+        assert mapped.shape == (expected_size,)
 
+        unmapped = weight_dense_unpack(mapped, weight_width, signed, size)
+        assert unmapped.dtype == weight.dtype
+        assert np.array_equal(weight, unmapped)
 
-@pytest.mark.parametrize(
-    "size, weight_width, signed",
-    [
-        (100, 8, True),
-        (128, 8, False),
-        (100, 4, True),
-        (64, 4, False),
-        (60, 2, True),
-        (200, 1, True),
-        (256, 1, False),
-        (0, 8, True),
-        (0, 8, False),
-    ],
-)
-def test_weight_csc_unpack(size, weight_width, signed, fixed_rng):
-    weight = gen_v2_weight_array(
-        size, weight_width, signed, fixed_rng, sparse_ratio=0.4
+    @pytest.mark.parametrize(
+        "weight_width, weight, expected",
+        [
+            (
+                8,
+                np.arange(1, 17, dtype=np.uint8),
+                np.array(
+                    [0x0807060504030201, 0x100F0E0D0C0B0A09],
+                    dtype=FRAME_DTYPE,
+                ),
+            ),
+            (
+                4,
+                np.arange(16, dtype=np.uint8),
+                np.array(
+                    [0xFEDCBA9876543210, 0x0000000000000000],
+                    dtype=FRAME_DTYPE,
+                ),
+            ),
+            (
+                2,
+                np.arange(16, dtype=np.uint8) % 4,
+                np.array(
+                    [0x00000000E4E4E4E4, 0x0000000000000000],
+                    dtype=FRAME_DTYPE,
+                ),
+            ),
+            (
+                1,
+                np.tile(np.array([0, 1], dtype=np.uint8), 8),
+                np.array(
+                    [0x000000000000AAAA, 0x0000000000000000],
+                    dtype=FRAME_DTYPE,
+                ),
+            ),
+        ],
+        ids=["8bit", "4bit", "2bit", "1bit"],
     )
-    mapped = weight_csc_pack(weight, weight_width, input_width=1)
+    def test_weight_dense_pack_manual_layout(self, weight_width, weight, expected):
+        mapped = weight_dense_pack(weight, weight_width)
 
-    n_nonzero_per_addr = {1: 7, 2: 7, 4: 6, 8: 5}[weight_width]
-    expected_size = math.ceil(np.count_nonzero(weight) / n_nonzero_per_addr) * 2
+        assert mapped.dtype == FRAME_DTYPE
+        assert np.array_equal(mapped, expected)
 
-    assert mapped.dtype == FRAME_DTYPE
-    assert mapped.shape == (expected_size,)
+    def test_weight_dense_pack_signed_low_width_masks_twos_complement(self):
+        weight = np.array([-1, -2, 3, 0], dtype=np.int8)
+        mapped = weight_dense_pack(weight, 4)
 
-    unmapped = weight_csc_unpack(mapped, weight_width, signed, size)
-    assert unmapped.dtype == weight.dtype
-    assert np.array_equal(weight, unmapped)
+        expected = np.array([0x00000000000003EF, 0x0000000000000000], dtype=FRAME_DTYPE)
+        assert np.array_equal(mapped, expected)
 
-
-def test_weight_csc_pack_8bit_layout():
-    weight = np.array([0, 1, 0, 2, 0, 3, 0, 4, 0, 5], dtype=np.uint8)
-    mapped = weight_csc_pack(weight, 8, input_width=1)
-
-    expected_low = (
-        FRAME_DTYPE(1)
-        | (FRAME_DTYPE(2) << 8)
-        | (FRAME_DTYPE(3) << 16)
-        | (FRAME_DTYPE(4) << 24)
-        | (FRAME_DTYPE(5) << 32)
-        | (FRAME_DTYPE(1) << 48)
+    @pytest.mark.parametrize(
+        "size, weight_width, signed",
+        [
+            (100, 8, True),
+            (128, 8, False),
+            (100, 4, True),
+            (64, 4, False),
+            (60, 2, True),
+            (200, 1, True),
+            (256, 1, False),
+            (0, 8, True),
+            (0, 8, False),
+        ],
     )
-    expected_high = (
-        FRAME_DTYPE(3)
-        | (FRAME_DTYPE(5) << 16)
-        | (FRAME_DTYPE(7) << 32)
-        | (FRAME_DTYPE(9) << 48)
+    def test_weight_csc_unpack(self, size, weight_width, signed, fixed_rng):
+        weight = gen_v2_weight_array(
+            size, weight_width, signed, fixed_rng, sparse_ratio=0.4
+        )
+        mapped = weight_csc_pack(weight, weight_width, 1)
+
+        n_nonzero_per_addr = {1: 7, 2: 7, 4: 6, 8: 5}[weight_width]
+        expected_size = math.ceil(np.count_nonzero(weight) / n_nonzero_per_addr) * 2
+
+        assert mapped.dtype == FRAME_DTYPE
+        assert mapped.shape == (expected_size,)
+
+        unmapped = weight_csc_unpack(mapped, weight_width, signed, size)
+        assert unmapped.dtype == weight.dtype
+        assert np.array_equal(weight, unmapped)
+
+    def test_weight_csc_pack_8bit_layout(self):
+        weight = np.array([0, 1, 0, 2, 0, 3, 0, 4, 0, 5], dtype=np.uint8)
+        mapped = weight_csc_pack(weight, 8, 1)
+        expected = pack_offline_csc_8bit_record_for_test(
+            payload=[1, 2, 3, 4, 5],
+            indices=[1, 3, 5, 7, 9],
+        )
+
+        assert np.array_equal(mapped, expected)
+
+    def test_weight_csc_pack_8bit_input_width_uses_bit_indices(self):
+        weight = np.array([1, 0, 2, 0, 3], dtype=np.uint8)
+        mapped = weight_csc_pack(weight, 8, 8)
+
+        assert csc_index_fields(mapped, 8)[:3].tolist() == [0, 16, 32]
+
+    def test_weight_csc_pack_8bit_multi_record_padding_repeats_last_index(self):
+        weight = np.zeros(64, dtype=np.uint8)
+        weight[[0, 8, 16, 24, 32, 48]] = [3, 2, 1, 9, 1, 1]
+
+        mapped = weight_csc_pack(weight, 8, 8)
+
+        assert csc_index_fields(mapped, 8).reshape(2, 5).tolist() == [
+            [0, 64, 128, 192, 256],
+            [384, 384, 384, 384, 384],
+        ]
+        assert csc_payload_fields(mapped, 8).reshape(2, 5).tolist() == [
+            [3, 2, 1, 9, 1],
+            [1, 0, 0, 0, 0],
+        ]
+
+    @pytest.mark.parametrize(
+        "weight_width,n_nonzero_per_record",
+        [(1, 7), (2, 7), (4, 6), (8, 5)],
+        ids=["1bit", "2bit", "4bit", "8bit"],
     )
+    def test_weight_csc_pack_padding_repeats_last_index_by_width(
+        self, weight_width, n_nonzero_per_record
+    ):
+        weight = np.ones(n_nonzero_per_record + 1, dtype=np.uint8)
+        input_width = 8
 
-    assert np.array_equal(
-        mapped, np.array([expected_low, expected_high], dtype=FRAME_DTYPE)
+        mapped = weight_csc_pack(weight, weight_width, input_width)
+
+        expected_indices = [
+            [i * input_width for i in range(n_nonzero_per_record)],
+            [n_nonzero_per_record * input_width] * n_nonzero_per_record,
+        ]
+        expected_payload = [
+            [1] * n_nonzero_per_record,
+            [1] + [0] * (n_nonzero_per_record - 1),
+        ]
+        assert (
+            csc_index_fields(mapped, weight_width)
+            .reshape(2, n_nonzero_per_record)
+            .tolist()
+            == expected_indices
+        )
+        assert (
+            csc_payload_fields(mapped, weight_width)
+            .reshape(2, n_nonzero_per_record)
+            .tolist()
+            == expected_payload
+        )
+
+    def test_weight_csc_unpack_ignores_repeated_zero_payload_padding(self):
+        weight = np.zeros(64, dtype=np.uint8)
+        weight[[0, 8, 16, 24, 32, 48]] = [3, 2, 1, 9, 1, 1]
+
+        mapped = weight_csc_pack(weight, 8, 8)
+        unpacked = weight_csc_unpack(mapped, 8, False, weight.size, input_width=8)
+
+        assert np.array_equal(unpacked, weight)
+
+    def test_weight_csc_unpack_manual_8bit_layout(self):
+        frames = np.array([0x0001000504030201, 0x0009000700050003], dtype=FRAME_DTYPE)
+
+        unmapped = weight_csc_unpack(frames, 8, False, 10)
+
+        expected = np.array([0, 1, 0, 2, 0, 3, 0, 4, 0, 5], dtype=np.uint8)
+        assert np.array_equal(unmapped, expected)
+
+    def test_weight_csc_pack_input_width_one_uses_sparse_row_indices(self):
+        weight = np.array([0, 1, 0, 2, 0, 3, 0, 4, 0, 5], dtype=np.uint8)
+        mapped = weight_csc_pack(weight, 8, 1)
+
+        assert csc_index_fields(mapped, 8).tolist() == [1, 3, 5, 7, 9]
+
+    def test_weight_csc_unpack_rejects_odd_frame_count(self):
+        with pytest.raises(ValueError, match="even"):
+            weight_csc_unpack(np.array([1], dtype=FRAME_DTYPE), 8, True, 1)
+
+    @pytest.mark.parametrize(
+        "size, sparse",
+        [(64, False), (64, True), (65, False)],
+        ids=["dense_need_align", "sparse_need_align", "dense_no_align"],
     )
+    def test_weight_csc_pack_allows_unaligned_sparse_records(self, size, sparse):
+        weight = np.ones(size, dtype=np.int8)
+        if sparse:
+            weight[5] = 0
+
+        weight_csc_pack(weight, 8, 1)
 
 
-def test_weight_csc_unpack_rejects_odd_frame_count():
-    with pytest.raises(ValueError, match="even"):
-        weight_csc_unpack(np.array([1], dtype=FRAME_DTYPE), 8, True, 1)
+class TestOnlineWeightPackV2:
+    def test_online_weight_csc_pack_all_nonzero_unaligned_repeats_last_index(self):
+        weight = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float16)
 
+        result = online_weight_csc_pack(weight)
+        expected = np.concatenate(
+            [
+                pack_online_csc_record_for_test([1.0, 2.0, 3.0, 4.0], [0, 1, 2, 3]),
+                pack_online_csc_record_for_test([5.0, 0.0, 0.0, 0.0], [4, 4, 4, 4]),
+            ]
+        )
 
-@pytest.mark.parametrize(
-    "size, sparse, expectation",
-    [
-        (64, False, pytest.raises(ValueError)),
-        (64, True, contextlib.nullcontext()),
-        (65, False, contextlib.nullcontext()),
-    ],
-    ids=["dense_need_align", "sparse_need_align", "dense_no_align"],
-)
-def test_weightcsc_unpack_check_aligned(size, sparse, expectation):
-    weight = np.ones(size, dtype=np.int8)
-    if sparse:
-        weight[5] = 0
+        assert np.array_equal(result, expected)
 
-    with expectation:
-        weight_csc_pack(weight, 8, 8)
+    @pytest.mark.parametrize("float_dtype", [np.float16, np.float32, np.float64])
+    def test_online_weight_dense_pack_8_bf16_weights(self, float_dtype):
+        weight = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=float_dtype)
+        result = online_weight_dense_pack(weight)
+        expected_bits = pack_bf16_payload_bits(weight).astype(FRAME_DTYPE, copy=False)
+        shifts = 16 * np.arange(4, dtype=FRAME_DTYPE)
+        expected = np.array(
+            [
+                np.bitwise_or.reduce(expected_bits[:4] << shifts, dtype=FRAME_DTYPE),
+                np.bitwise_or.reduce(expected_bits[4:] << shifts, dtype=FRAME_DTYPE),
+            ],
+            dtype=FRAME_DTYPE,
+        )
+
+        assert result.shape == (2,)
+        assert np.array_equal(result, expected)
+
+    def test_online_weight_dense_pack_pads_to_8_bf16_weights(self):
+        weight = np.array([1.0, -2.0, 3.25, 0.5, 9.0], dtype=np.float32)
+        result = online_weight_dense_pack(weight)
+        bits = pack_bf16_payload_bits(weight)
+
+        expected = np.array(
+            [
+                pack_u16_lanes_for_test(bits[:4]),
+                pack_u16_lanes_for_test([bits[4], 0, 0, 0]),
+            ],
+            dtype=FRAME_DTYPE,
+        )
+
+        assert result.shape == (2,)
+        assert np.array_equal(result, expected)
+
+    def test_online_weight_csc_pack_layout(self):
+        weight = np.array([0.0, 1.0, 0.0, -2.0, 3.25], dtype=np.float32)
+        result = online_weight_csc_pack(weight)
+        expected = pack_online_csc_record_for_test([1.0, -2.0, 3.25, 0.0], [1, 3, 4, 4])
+
+        assert result.shape == (2,)
+        assert np.array_equal(result, expected)
+
+    def test_online_weight_csc_pack_multi_record_padding_repeats_last_index(self):
+        weight = np.zeros(10, dtype=np.float32)
+        weight[[0, 2, 4, 8, 9]] = [1.0, -2.0, 3.25, 0.5, -1.5]
+
+        result = online_weight_csc_pack(weight)
+        expected = np.concatenate(
+            [
+                pack_online_csc_record_for_test([1.0, -2.0, 3.25, 0.5], [0, 2, 4, 8]),
+                pack_online_csc_record_for_test([-1.5, 0.0, 0.0, 0.0], [9, 9, 9, 9]),
+            ]
+        )
+
+        assert np.array_equal(result, expected)
+
+    @pytest.mark.parametrize("float_dtype", [np.float16, np.float32, np.float64])
+    def test_online_weight_dense_unpack(self, float_dtype):
+        rng = np.random.default_rng(20260428)
+        weight = rng.uniform(-8.0, 8.0, 77).astype(float_dtype)
+        mapped = online_weight_dense_pack(weight)
+
+        unpacked = online_weight_dense_unpack(mapped, weight.size)
+        assert unpacked.dtype == np.uint16
+        assert np.array_equal(unpacked, pack_bf16_payload_bits(weight).ravel())
+
+    @pytest.mark.parametrize("float_dtype", [np.float16, np.float32, np.float64])
+    def test_online_weight_csc_unpack(self, float_dtype):
+        rng = np.random.default_rng(20260428)
+        weight = rng.uniform(-8.0, 8.0, 77).astype(float_dtype)
+        weight[rng.choice(weight.size, size=weight.size // 4, replace=False)] = 0
+        mapped = online_weight_csc_pack(weight)
+
+        unpacked = online_weight_csc_unpack(mapped, weight.size)
+        assert unpacked.dtype == np.uint16
+        assert np.array_equal(unpacked, pack_bf16_payload_bits(weight).ravel())

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0b4"
+version = "2.0.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "platform_machine == 'armv7l'" },


### PR DESCRIPTION
## Summary

- Fix V2 work-frame timestamp/axon packing around physical axon widths and LCN-relative ticks.
- Update offline and online CSC sparse weight packing so padding lanes use zero payloads and repeat the last real index.
- Add focused framelib coverage for work-frame edge cases, CSC bit indices, repeated-index padding, and online/offline pack/unpack paths.