### PR TITLE
feat(framelib): add V2 frame parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paicorelib"
-version = "2.0.0rc2"
+version = "2.0.0rc3"
 description = "Library of PAICORE"
 authors = [{ name = "Ziru Pan", email = "zrpan@stu.pku.edu.cn" }]
 license = "GPL-3.0-or-later"

--- a/src/paicorelib/framelib/parser_v2.py
+++ b/src/paicorelib/framelib/parser_v2.py
@@ -1,0 +1,475 @@
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from ..coordinate import CoordXY, CoordZXYOffset
+from ..routing_hexa import AERPacket, AERPacketZXYCopy, aer_packet_walk
+from .frame_defs import FFV2, OfflineConfigFrame1FormatV2, OfflineConfigFrame2FormatV2
+from .frame_defs import FrameHeader as FH
+from .types import FrameArrayLike
+from .utils import frame_array2np
+
+__all__ = [
+    "AerRouteFields",
+    "FrameHeaderInfo",
+    "FramePackageInfo",
+    "FrameParseError",
+    "LutEntry",
+    "ParsedCoreFrames",
+    "ParsedFrameStream",
+    "bit_field",
+    "decode_aer_route_fields",
+    "decode_core_config",
+    "decode_header",
+    "decode_lut_entries",
+    "expand_aer_destinations",
+    "parse_frame_stream",
+    "sign_magnitude_to_int",
+]
+
+CONFIG1_WORDS = 3
+LUT_ENTRIES = 256
+SRAM_WORDS = 2
+
+
+class FrameParseError(ValueError):
+    """Raised when a V2 frame stream cannot be decoded as config packages."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        frame_index: int | None = None,
+        raw_frame: int | None = None,
+        context: dict[str, int | str] | None = None,
+    ) -> None:
+        self.reason = message
+        self.frame_index = frame_index
+        self.raw_frame = raw_frame
+        self.context = context or {}
+        details = []
+        if frame_index is not None:
+            details.append(f"frame_index={frame_index}")
+        if raw_frame is not None:
+            details.append(f"raw=0x{raw_frame:016x}")
+        details.extend(f"{key}={value}" for key, value in self.context.items())
+        suffix = f" ({', '.join(details)})" if details else ""
+        super().__init__(f"{message}{suffix}")
+
+
+@dataclass(frozen=True)
+class FrameHeaderInfo:
+    """Decoded common fields of one PAICORE 2.5 frame header."""
+
+    index: int
+    value: int
+    frame_type: int
+    header: int
+    offset_z: int
+    offset_x: int
+    offset_y: int
+    copy_z: int
+    copy_x: int
+    copy_y: int
+    payload: int
+
+    @property
+    def x(self) -> int:
+        return self.offset_z + self.offset_x
+
+    @property
+    def y(self) -> int:
+        return self.offset_z + self.offset_y
+
+    @property
+    def coord(self) -> CoordXY:
+        return CoordXY(self.x, self.y)
+
+    @property
+    def coord_key(self) -> tuple[int, int]:
+        return self.x, self.y
+
+    @property
+    def offset(self) -> CoordZXYOffset:
+        return CoordZXYOffset(self.offset_z, self.offset_x, self.offset_y)
+
+    @property
+    def ncopy(self) -> AERPacketZXYCopy:
+        return AERPacketZXYCopy(self.copy_z, self.copy_x, self.copy_y)
+
+
+@dataclass(frozen=True)
+class FramePackageInfo:
+    """One V2 config-frame package header and its payload frames."""
+
+    frame_type: int
+    start_addr: int
+    package_type: int
+    package_count: int
+    frame_start: int
+    frame_end: int
+    header: int
+    payloads: tuple[int, ...]
+
+    @property
+    def header_hex(self) -> str:
+        return f"0x{self.header:016x}"
+
+    @property
+    def payload_hex(self) -> tuple[str, ...]:
+        return tuple(f"0x{value:016x}" for value in self.payloads)
+
+
+@dataclass
+class ParsedCoreFrames:
+    x: int
+    y: int
+    frame_type1_payloads: list[int] = field(default_factory=list)
+    frame_type2_payloads: list[int] = field(default_factory=list)
+    frame_type3_payloads: list[int] = field(default_factory=list)
+    packages: list[FramePackageInfo] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ParsedFrameStream:
+    frame_count: int
+    packages: list[FramePackageInfo]
+    cores: dict[tuple[int, int], ParsedCoreFrames]
+
+
+@dataclass(frozen=True)
+class AerRouteFields:
+    offset_z: int
+    offset_x: int
+    offset_y: int
+    copy_z: int
+    copy_x: int
+    copy_y: int
+
+    @property
+    def offset(self) -> CoordZXYOffset:
+        return CoordZXYOffset(self.offset_z, self.offset_x, self.offset_y)
+
+    @property
+    def ncopy(self) -> AERPacketZXYCopy:
+        return AERPacketZXYCopy(self.copy_z, self.copy_x, self.copy_y)
+
+
+@dataclass(frozen=True)
+class LutEntry:
+    index: int
+    potential: int
+    activation: int
+    raw: int
+
+
+def bit_field(value: int, offset: int, mask: int) -> int:
+    return (value >> offset) & mask
+
+
+def sign_magnitude_to_int(value: int, bits: int = 6) -> int:
+    sign = value >> (bits - 1)
+    magnitude = value & ((1 << (bits - 1)) - 1)
+    return -magnitude if sign else magnitude
+
+
+def decode_header(frame: int, index: int = 0) -> FrameHeaderInfo:
+    header = bit_field(frame, FFV2.GENERAL_HEADER_OFFSET, FFV2.GENERAL_HEADER_MASK)
+    return FrameHeaderInfo(
+        index=index,
+        value=frame,
+        frame_type=bit_field(
+            frame, FFV2.GENERAL_FRAME_TYPE_OFFSET, FFV2.GENERAL_FRAME_TYPE_MASK
+        ),
+        header=header,
+        offset_z=sign_magnitude_to_int(
+            bit_field(
+                frame, FFV2.GENERAL_CORE_XY_ADDR_OFFSET, FFV2.GENERAL_CORE_XY_ADDR_MASK
+            )
+        ),
+        offset_x=sign_magnitude_to_int(
+            bit_field(
+                frame, FFV2.GENERAL_CORE_X_ADDR_OFFSET, FFV2.GENERAL_CORE_X_ADDR_MASK
+            )
+        ),
+        offset_y=sign_magnitude_to_int(
+            bit_field(
+                frame, FFV2.GENERAL_CORE_Y_ADDR_OFFSET, FFV2.GENERAL_CORE_Y_ADDR_MASK
+            )
+        ),
+        copy_z=sign_magnitude_to_int(
+            bit_field(
+                frame, FFV2.GENERAL_COPY_XY_ADDR_OFFSET, FFV2.GENERAL_COPY_XY_ADDR_MASK
+            )
+        ),
+        copy_x=sign_magnitude_to_int(
+            bit_field(
+                frame, FFV2.GENERAL_COPY_X_ADDR_OFFSET, FFV2.GENERAL_COPY_X_ADDR_MASK
+            )
+        ),
+        copy_y=sign_magnitude_to_int(
+            bit_field(
+                frame, FFV2.GENERAL_COPY_Y_ADDR_OFFSET, FFV2.GENERAL_COPY_Y_ADDR_MASK
+            )
+        ),
+        payload=bit_field(
+            frame, FFV2.GENERAL_PAYLOAD_OFFSET, FFV2.GENERAL_PAYLOAD_MASK
+        ),
+    )
+
+
+def parse_frame_stream(frames: FrameArrayLike) -> ParsedFrameStream:
+    """Parse V2 config-frame packages without assuming any package order."""
+    array = frame_array2np(frames)
+    cores: dict[tuple[int, int], ParsedCoreFrames] = {}
+    packages: list[FramePackageInfo] = []
+    cursor = 0
+
+    while cursor < len(array):
+        header = decode_header(int(array[cursor]), cursor)
+        if header.header not in {FH.CONFIG_TYPE1, FH.CONFIG_TYPE2, FH.CONFIG_TYPE3}:
+            raise FrameParseError(
+                "unsupported frame header in V2 config stream",
+                frame_index=cursor,
+                raw_frame=int(array[cursor]),
+                context={"header": header.header},
+            )
+
+        package_count = bit_field(
+            header.payload,
+            FFV2.GENERAL_PACKAGE_NUM_OFFSET,
+            FFV2.GENERAL_PACKAGE_NUM_MASK,
+        )
+        frame_end = cursor + package_count
+        if frame_end >= len(array):
+            raise FrameParseError(
+                "truncated V2 config frame package",
+                frame_index=cursor,
+                raw_frame=int(array[cursor]),
+                context={
+                    "header": header.header,
+                    "package_count": package_count,
+                    "frame_count": len(array),
+                },
+            )
+
+        payloads = tuple(int(v) for v in array[cursor + 1 : cursor + 1 + package_count])
+        package = FramePackageInfo(
+            frame_type=header.header + 1,
+            start_addr=bit_field(
+                header.payload,
+                FFV2.GENERAL_PACKAGE_NEU_START_ADDR_OFFSET,
+                FFV2.GENERAL_PACKAGE_NEU_START_ADDR_MASK,
+            ),
+            package_type=bit_field(
+                header.payload,
+                FFV2.GENERAL_PACKAGE_TYPE_OFFSET,
+                FFV2.GENERAL_PACKAGE_TYPE_MASK,
+            ),
+            package_count=package_count,
+            frame_start=cursor,
+            frame_end=frame_end,
+            header=int(array[cursor]),
+            payloads=payloads,
+        )
+        _require_package_shape(package)
+        packages.append(package)
+
+        coord_key = header.coord_key
+        core = cores.setdefault(
+            coord_key, ParsedCoreFrames(x=coord_key[0], y=coord_key[1])
+        )
+        core.packages.append(package)
+        if header.header == FH.CONFIG_TYPE1:
+            core.frame_type1_payloads.extend(payloads)
+        elif header.header == FH.CONFIG_TYPE2:
+            core.frame_type2_payloads.extend(payloads)
+        else:
+            core.frame_type3_payloads.extend(payloads)
+        cursor = frame_end + 1
+
+    return ParsedFrameStream(frame_count=len(array), packages=packages, cores=cores)
+
+
+def decode_core_config(payloads: Sequence[int]) -> dict[str, int]:
+    """Decode the first complete offline config-frame type1 payload group."""
+    if len(payloads) < CONFIG1_WORDS:
+        raise FrameParseError(
+            "config frame type1 requires at least 3 payload words",
+            context={"payload_count": len(payloads)},
+        )
+
+    f = OfflineConfigFrame1FormatV2
+    w1, w2, w3 = (int(payloads[0]), int(payloads[1]), int(payloads[2]))
+    test_core_y = (
+        bit_field(w1, f.Word1.TEST_CORE_Y_HIGH2_OFFSET, f.Word1.TEST_CORE_Y_HIGH2_MASK)
+        << 4
+    ) | bit_field(w2, f.Word2.TEST_CORE_Y_LOW4_OFFSET, f.Word2.TEST_CORE_Y_LOW4_MASK)
+    return {
+        "snn_ann": bit_field(w1, f.Word1.SNN_ANN_OFFSET, f.Word1.SNN_ANN_MASK),
+        "max_pooling": bit_field(
+            w1, f.Word1.MAX_POOLING_OFFSET, f.Word1.MAX_POOLING_MASK
+        ),
+        "add_potential": bit_field(
+            w1, f.Word1.ADD_POTENTIAL_OFFSET, f.Word1.ADD_POTENTIAL_MASK
+        ),
+        "zero_output": bit_field(
+            w1, f.Word1.ZERO_OUTPUT_OFFSET, f.Word1.ZERO_OUTPUT_MASK
+        ),
+        "input_sign": bit_field(w1, f.Word1.INPUT_SIGN_OFFSET, f.Word1.INPUT_SIGN_MASK),
+        "input_width": bit_field(
+            w1, f.Word1.INPUT_WIDTH_OFFSET, f.Word1.INPUT_WIDTH_MASK
+        ),
+        "output_sign": bit_field(
+            w1, f.Word1.OUTPUT_SIGN_OFFSET, f.Word1.OUTPUT_SIGN_MASK
+        ),
+        "output_width": bit_field(
+            w1, f.Word1.OUTPUT_WIDTH_OFFSET, f.Word1.OUTPUT_WIDTH_MASK
+        ),
+        "weight_sign": bit_field(
+            w1, f.Word1.WEIGHT_SIGN_OFFSET, f.Word1.WEIGHT_SIGN_MASK
+        ),
+        "weight_width": bit_field(
+            w1, f.Word1.WEIGHT_WIDTH_OFFSET, f.Word1.WEIGHT_WIDTH_MASK
+        ),
+        "lcn": bit_field(w1, f.Word1.LCN_OFFSET, f.Word1.LCN_MASK),
+        "target_lcn": bit_field(w1, f.Word1.TARGET_LCN_OFFSET, f.Word1.TARGET_LCN_MASK),
+        "axon_skew": bit_field(w1, f.Word1.AXON_SKEW_OFFSET, f.Word1.AXON_SKEW_MASK),
+        "neuron_number": bit_field(
+            w1, f.Word1.NEURON_NUMBER_OFFSET, f.Word1.NEURON_NUMBER_MASK
+        ),
+        "test_core_xy": bit_field(
+            w1, f.Word1.TEST_CORE_XY_OFFSET, f.Word1.TEST_CORE_XY_MASK
+        ),
+        "test_core_x": bit_field(
+            w1, f.Word1.TEST_CORE_X_OFFSET, f.Word1.TEST_CORE_X_MASK
+        ),
+        "test_core_y": test_core_y,
+        "global_send": bit_field(
+            w2, f.Word2.GLOBAL_SEND_OFFSET, f.Word2.GLOBAL_SEND_MASK
+        ),
+        "csc_accelerate": bit_field(
+            w2, f.Word2.CSC_ACCELERATE_OFFSET, f.Word2.CSC_ACCELERATE_MASK
+        ),
+        "global_receive": bit_field(
+            w2, f.Word2.GLOBAL_RECEIVE_OFFSET, f.Word2.GLOBAL_RECEIVE_MASK
+        ),
+        "thread_number": bit_field(
+            w2, f.Word2.THREAD_NUMBER_OFFSET, f.Word2.THREAD_NUMBER_MASK
+        ),
+        "busy_cycle": bit_field(w2, f.Word2.BUSY_CYCLE_OFFSET, f.Word2.BUSY_CYCLE_MASK),
+        "delay_cycle": bit_field(
+            w2, f.Word2.DELAY_CYCLE_OFFSET, f.Word2.DELAY_CYCLE_MASK
+        ),
+        "width_cycle": bit_field(
+            w2, f.Word2.WIDTH_CYCLE_OFFSET, f.Word2.WIDTH_CYCLE_MASK
+        ),
+        "tick_start": bit_field(w3, f.Word3.TICK_START_OFFSET, f.Word3.TICK_START_MASK),
+        "tick_duration": bit_field(
+            w3, f.Word3.TICK_DURATION_OFFSET, f.Word3.TICK_DURATION_MASK
+        ),
+        "tick_initial": bit_field(
+            w3, f.Word3.TICK_INITIAL_OFFSET, f.Word3.TICK_INITIAL_MASK
+        ),
+    }
+
+
+def decode_lut_entries(payloads: list[int] | tuple[int, ...]) -> list[LutEntry]:
+    if len(payloads) < LUT_ENTRIES:
+        raise FrameParseError(
+            "config frame type2 LUT requires at least 256 payload words",
+            context={"payload_count": len(payloads)},
+        )
+
+    f = OfflineConfigFrame2FormatV2
+    return [
+        LutEntry(
+            index=index,
+            potential=twos_complement_to_int(
+                bit_field(value, f.POTENTIAL_OFFSET, f.POTENTIAL_MASK), 32
+            ),
+            activation=bit_field(value, f.ACTIVATION_OFFSET, f.ACTIVATION_MASK),
+            raw=value,
+        )
+        for index, value in enumerate(payloads[:LUT_ENTRIES])
+    ]
+
+
+def decode_aer_route_fields(
+    addr_core_xy: int,
+    addr_core_x: int,
+    addr_core_y: int,
+    addr_copy_xy: int,
+    addr_copy_x: int,
+    addr_copy_y: int,
+) -> AerRouteFields:
+    return AerRouteFields(
+        offset_z=sign_magnitude_to_int(addr_core_xy),
+        offset_x=sign_magnitude_to_int(addr_core_x),
+        offset_y=sign_magnitude_to_int(addr_core_y),
+        copy_z=sign_magnitude_to_int(addr_copy_xy),
+        copy_x=sign_magnitude_to_int(addr_copy_x),
+        copy_y=sign_magnitude_to_int(addr_copy_y),
+    )
+
+
+def expand_aer_destinations(
+    source: CoordXY | tuple[int, int], route: AerRouteFields
+) -> list[CoordXY]:
+    source_coord = source.copy() if isinstance(source, CoordXY) else CoordXY(*source)
+    packet = AERPacket(source_coord, route.offset, route.ncopy)
+    return aer_packet_walk(packet)
+
+
+def twos_complement_to_int(value: int, bits: int) -> int:
+    sign_bit = 1 << (bits - 1)
+    mask = (1 << bits) - 1
+    value &= mask
+    return value - (1 << bits) if value & sign_bit else value
+
+
+def _require_package_shape(package: FramePackageInfo) -> None:
+    if package.frame_end != package.frame_start + package.package_count:
+        raise FrameParseError(
+            "truncated V2 config frame package",
+            frame_index=package.frame_start,
+            raw_frame=package.header,
+            context={
+                "frame_type": package.frame_type,
+                "expected_end": package.frame_start + package.package_count,
+                "actual_end": package.frame_end,
+            },
+        )
+    if package.frame_type == 1 and package.package_count != CONFIG1_WORDS:
+        raise FrameParseError(
+            "config frame type1 must contain exactly 3 payload words",
+            frame_index=package.frame_start,
+            raw_frame=package.header,
+            context={"package_count": package.package_count},
+        )
+    if package.frame_type == 2 and package.package_count != LUT_ENTRIES:
+        raise FrameParseError(
+            "config frame type2 LUT must contain exactly 256 entries",
+            frame_index=package.frame_start,
+            raw_frame=package.header,
+            context={"package_count": package.package_count},
+        )
+    if package.frame_type == 3 and package.package_count % SRAM_WORDS:
+        raise FrameParseError(
+            "config frame type3 payload must contain whole 128-bit SRAM records",
+            frame_index=package.frame_start,
+            raw_frame=package.header,
+            context={"package_count": package.package_count},
+        )
+    if (
+        package.frame_type == 3
+        and package.start_addr + package.package_count // SRAM_WORDS > 4096
+    ):
+        raise FrameParseError(
+            "config frame type3 SRAM address range exceeds 4096 records",
+            frame_index=package.frame_start,
+            raw_frame=package.header,
+            context={
+                "start_addr": package.start_addr,
+                "package_count": package.package_count,
+            },
+        )

--- a/src/paicorelib/framelib/types.py
+++ b/src/paicorelib/framelib/types.py
@@ -1,4 +1,5 @@
-from typing import TypeVar
+from collections.abc import Iterable
+from typing import TypeAlias, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -17,8 +18,9 @@ LUTPotentialType = NDArray[LUT_POTENTIAL_DTYPE]
 LUT_ACTIVATION_DTYPE = np.int8 | np.uint8
 LUTActivationType = NDArray[LUT_ACTIVATION_DTYPE]
 
-FrameArrayLike = TypeVar(
-    "FrameArrayLike", int, list[int], tuple[int, ...], NDArray[FRAME_DTYPE]
+FrameScalarLike: TypeAlias = int | np.integer
+FrameArrayLike: TypeAlias = (
+    FrameScalarLike | Iterable[FrameScalarLike] | NDArray[FRAME_DTYPE]
 )
 IntScalarType = TypeVar("IntScalarType", int, bool, np.integer)
 DataType = TypeVar("DataType", int, bool, np.integer, np.ndarray)

--- a/src/paicorelib/framelib/utils.py
+++ b/src/paicorelib/framelib/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from functools import wraps
 from pathlib import Path
 from typing import Any, Literal, SupportsIndex, overload
@@ -100,8 +100,13 @@ def framearray_header_check(
 
 
 def frame_array2np(frame_array: FrameArrayLike) -> FrameArrayType:
-    if isinstance(frame_array, int):
+    if isinstance(frame_array, (int, np.integer)):
         return np.asarray([frame_array], dtype=FRAME_DTYPE)
+
+    elif isinstance(frame_array, (str, bytes, bytearray)):
+        raise TypeError(
+            f"expected int, iterable or np.ndarray, but got {type(frame_array).__name__}."
+        )
 
     elif isinstance(frame_array, np.ndarray):
         if frame_array.ndim != 1:
@@ -111,12 +116,12 @@ def frame_array2np(frame_array: FrameArrayLike) -> FrameArrayType:
             )
         return frame_array.flatten().astype(FRAME_DTYPE)
 
-    elif isinstance(frame_array, (list, tuple)):
-        return np.asarray(frame_array, dtype=FRAME_DTYPE)
+    elif isinstance(frame_array, Iterable):
+        return np.fromiter(frame_array, dtype=FRAME_DTYPE)
 
     else:
         raise TypeError(
-            f"expected int, list, tuple or np.ndarray, but got {type(frame_array).__name__}."
+            f"expected int, iterable or np.ndarray, but got {type(frame_array).__name__}."
         )
 
 

--- a/tests/framelib/test_parser_v2.py
+++ b/tests/framelib/test_parser_v2.py
@@ -1,0 +1,218 @@
+import numpy as np
+import pytest
+
+from paicorelib.coordinate import CoordXY, CoordZXYOffset, coordzxy_to_sign_magnitude
+from paicorelib.core_defs import LCN_EX
+from paicorelib.core_defs_v2 import DataWidth
+from paicorelib.framelib.frame_defs import FFV2
+from paicorelib.framelib.frame_defs import FrameHeader as FH
+from paicorelib.framelib.frame_defs import OfflineConfigFrame1FormatV2 as Off_Cfg1_V2
+from paicorelib.framelib.frame_gen_v2 import OfflineFrameGenV2
+from paicorelib.framelib.parser_v2 import (
+    FrameParseError,
+    bit_field,
+    decode_aer_route_fields,
+    decode_core_config,
+    decode_header,
+    decode_lut_entries,
+    expand_aer_destinations,
+    parse_frame_stream,
+    sign_magnitude_to_int,
+)
+from paicorelib.routing_hexa import AERPacket, AERPacketZXYCopy, aer_packet_walk
+from tests.utils import build_v2_core_reg_params
+
+
+def _cf1(coord: CoordZXYOffset, **overrides) -> np.ndarray:
+    return OfflineFrameGenV2.gen_config_frame1(
+        coord, build_v2_core_reg_params(**overrides)
+    )
+
+
+def _cf2(coord: CoordZXYOffset) -> np.ndarray:
+    potential = np.arange(-128, 128, dtype=np.int32)
+    activation = np.arange(256, dtype=np.uint8)
+    return OfflineFrameGenV2.gen_config_frame2(coord, potential, activation)
+
+
+def _cf3_header(coord: CoordZXYOffset, start_addr: int, n_package: int) -> np.ndarray:
+    return OfflineFrameGenV2.gen_config_frame3_pkg_header(coord, start_addr, n_package)
+
+
+def test_decode_header_and_type1_core_config() -> None:
+    frames = _cf1(
+        CoordZXYOffset(1, 2, -1),
+        neuron_number=123,
+        lcn=LCN_EX.LCN_4X,
+        target_lcn=LCN_EX.LCN_8X,
+        input_width=DataWidth.WIDTH_4BIT,
+        test_core_xy=-3,
+        test_core_x=1,
+        test_core_y=0,
+        tick_start=7,
+    )
+
+    header = decode_header(int(frames[0]))
+    config = decode_core_config(tuple(int(v) for v in frames[1:]))
+
+    assert header.header == FH.CONFIG_TYPE1
+    assert header.offset == CoordZXYOffset(1, 2, -1)
+    assert header.coord_key == (3, 0)
+    assert config["neuron_number"] == 123
+    assert config["lcn"] == LCN_EX.LCN_4X.value
+    assert config["target_lcn"] == LCN_EX.LCN_8X.value
+    assert config["input_width"] == DataWidth.WIDTH_4BIT.value
+    assert config["tick_start"] == 7
+    assert sign_magnitude_to_int(config["test_core_xy"]) == -3
+    assert sign_magnitude_to_int(config["test_core_x"]) == 1
+    assert sign_magnitude_to_int(config["test_core_y"]) == 0
+
+
+def test_sign_magnitude_all_ones_is_negative_31() -> None:
+    assert sign_magnitude_to_int(0b111111) == -31
+
+
+def test_parse_frame_stream_accepts_ordered_config_packages() -> None:
+    frames = np.concatenate(
+        [
+            _cf1(CoordZXYOffset(0, 1, 1)),
+            _cf2(CoordZXYOffset(0, 1, 1)),
+            _cf3_header(CoordZXYOffset(0, 1, 1), start_addr=12, n_package=2),
+            np.array([0x11, 0x22], dtype=np.uint64),
+        ]
+    )
+    stream = parse_frame_stream(int(value) for value in frames)
+    core = stream.cores[(1, 1)]
+
+    assert [package.frame_type for package in stream.packages] == [1, 2, 3]
+    assert [package.frame_type for package in core.packages] == [1, 2, 3]
+    assert len(core.frame_type1_payloads) == 3
+    assert len(core.frame_type2_payloads) == 256
+    assert len(core.frame_type3_payloads) == 2
+
+
+def test_parse_frame_stream_accepts_repeated_and_unordered_config_packages() -> None:
+    stream = parse_frame_stream(
+        np.concatenate(
+            [
+                _cf1(CoordZXYOffset(0, 1, 1), neuron_number=1),
+                _cf1(CoordZXYOffset(0, 1, 1), neuron_number=2),
+                _cf3_header(CoordZXYOffset(0, 1, 1), start_addr=0, n_package=2),
+                np.array([0x33, 0x44], dtype=np.uint64),
+                _cf2(CoordZXYOffset(0, 1, 1)),
+            ]
+        )
+    )
+    core = stream.cores[(1, 1)]
+    config = decode_core_config(core.frame_type1_payloads)
+
+    assert [package.frame_type for package in core.packages] == [1, 1, 3, 2]
+    assert len(core.frame_type1_payloads) == 6
+    assert config["neuron_number"] == 1
+
+
+def test_parse_frame_stream_groups_interleaved_cores() -> None:
+    stream = parse_frame_stream(
+        np.concatenate(
+            [
+                _cf1(CoordZXYOffset(0, 1, 1), neuron_number=11),
+                _cf1(CoordZXYOffset(0, 2, 2), neuron_number=22),
+                _cf3_header(CoordZXYOffset(0, 1, 1), start_addr=4, n_package=2),
+                np.array([0x55, 0x66], dtype=np.uint64),
+            ]
+        )
+    )
+
+    assert set(stream.cores) == {(1, 1), (2, 2)}
+    assert [package.frame_type for package in stream.packages] == [1, 1, 3]
+    assert [package.frame_type for package in stream.cores[(1, 1)].packages] == [1, 3]
+    assert [package.frame_type for package in stream.cores[(2, 2)].packages] == [1]
+
+
+def test_parse_frame_stream_reports_truncated_package() -> None:
+    frames = _cf3_header(CoordZXYOffset(0, 1, 1), start_addr=0, n_package=2)
+
+    with pytest.raises(FrameParseError, match="truncated") as exc_info:
+        parse_frame_stream(frames)
+
+    assert exc_info.value.frame_index == 0
+    assert exc_info.value.raw_frame == int(frames[0])
+    assert exc_info.value.context["package_count"] == 2
+
+
+def test_parse_frame_stream_reports_unsupported_header() -> None:
+    bad = np.array([int(FH.WORK_TYPE1) << FFV2.GENERAL_HEADER_OFFSET], dtype=np.uint64)
+
+    with pytest.raises(FrameParseError, match="unsupported") as exc_info:
+        parse_frame_stream(bad)
+
+    assert exc_info.value.frame_index == 0
+    assert exc_info.value.context["header"] == int(FH.WORK_TYPE1)
+
+
+def test_decode_lut_entries_matches_generated_type2_payload() -> None:
+    frames = _cf2(CoordZXYOffset(0, 1, 1))
+    entries = decode_lut_entries(tuple(int(v) for v in frames[1:]))
+
+    assert len(entries) == 256
+    assert entries[0].potential == -128
+    assert entries[0].activation == 0
+    assert entries[-1].potential == 127
+    assert entries[-1].activation == 255
+
+
+def test_expand_aer_destinations_matches_paicorelib_walk() -> None:
+    offset = CoordZXYOffset(0, 3, 2)
+    ncopy = AERPacketZXYCopy(0, 1, 1)
+    raw_offset = coordzxy_to_sign_magnitude(offset)
+    raw_copy = ncopy.to_sign_magnitude()
+    route = decode_aer_route_fields(
+        addr_core_xy=raw_offset[0],
+        addr_core_x=raw_offset[1],
+        addr_core_y=raw_offset[2],
+        addr_copy_xy=raw_copy[0],
+        addr_copy_x=raw_copy[1],
+        addr_copy_y=raw_copy[2],
+    )
+    source = CoordXY(1, 1)
+
+    assert expand_aer_destinations(source, route) == aer_packet_walk(
+        AERPacket(source.copy(), offset, ncopy)
+    )
+
+
+def test_decode_core_config_uses_first_complete_type1_group() -> None:
+    first = _cf1(CoordZXYOffset(0, 1, 1), neuron_number=10)
+    second = _cf1(CoordZXYOffset(0, 1, 1), neuron_number=20)
+
+    config = decode_core_config(
+        tuple(int(v) for v in np.concatenate([first[1:], second[1:]]))
+    )
+
+    assert config["neuron_number"] == 10
+
+
+def test_decode_core_config_reconstructs_split_test_core_y_field() -> None:
+    frames = _cf1(CoordZXYOffset(0, 1, 1), test_core_y=-31)
+    w1, w2 = int(frames[1]), int(frames[2])
+    expected_raw_y = coordzxy_to_sign_magnitude(CoordZXYOffset(0, 0, -31))[2]
+
+    config = decode_core_config(tuple(int(v) for v in frames[1:]))
+
+    assert config["test_core_y"] == expected_raw_y
+    assert (
+        bit_field(
+            w1,
+            Off_Cfg1_V2.Word1.TEST_CORE_Y_HIGH2_OFFSET,
+            Off_Cfg1_V2.Word1.TEST_CORE_Y_HIGH2_MASK,
+        )
+        == 0b11
+    )
+    assert (
+        bit_field(
+            w2,
+            Off_Cfg1_V2.Word2.TEST_CORE_Y_LOW4_OFFSET,
+            Off_Cfg1_V2.Word2.TEST_CORE_Y_LOW4_MASK,
+        )
+        == 0b1111
+    )

--- a/tests/framelib/test_utils.py
+++ b/tests/framelib/test_utils.py
@@ -5,6 +5,7 @@ from paicorelib.framelib.frame_defs import FrameHeader as FH
 from paicorelib.framelib.types import FRAME_DTYPE
 from paicorelib.framelib.utils import (
     OFF_FRAME_WORK1_WIDTHS,
+    frame_array2np,
     framearray_header_check,
     print_frame,
 )
@@ -48,3 +49,14 @@ def test_framearray_header_check(frames):
 )
 def test_print_frame(frames):
     print_frame(frames, OFF_FRAME_WORK1_WIDTHS)
+
+
+@pytest.mark.parametrize(
+    ("frames", "expected"),
+    [(np.uint64(7), [7]), ((value for value in [1, 2]), [1, 2]), (range(3), [0, 1, 2])],
+)
+def test_frame_array2np_accepts_scalars_and_iterables(frames, expected):
+    array = frame_array2np(frames)
+
+    assert array.dtype == FRAME_DTYPE
+    assert array.tolist() == expected

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0rc2"
+version = "2.0.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "platform_machine == 'armv7l'" },


### PR DESCRIPTION
## Summary

- Add `paicorelib.framelib.parser_v2` for PAICORE 2.5 config frame parsing.
- Parse frame streams package-by-package without assuming type1/type2/type3 order.
- Group parsed packages by core while preserving global and per-core order.
- Decode type1 core config, type2 LUT entries, sign-magnitude fields, and AER route/copy expansion.
- Broaden `FrameArrayLike` / `frame_array2np()` to support numpy scalars and lazy integer iterables.
- Add focused parser and frame-array normalization coverage.
- Bump package version to `2.0.0rc3`.