### PR TITLE
feat(routing): add fast AER route helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,6 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
-    hooks:
-      - id: black
-        stages: [pre-commit]
-
   - repo: https://github.com/dannysepler/rm_unneeded_f_str
     rev: v0.2.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paicorelib"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 description = "Library of PAICORE"
 authors = [{ name = "Ziru Pan", email = "zrpan@stu.pku.edu.cn" }]
 license = "GPL-3.0-or-later"

--- a/src/paicorelib/__init__.py
+++ b/src/paicorelib/__init__.py
@@ -220,6 +220,8 @@ from .neuron_defs_v2 import (
 from .routing_hexa import (
     AERPacketZXYCopy,
     AERPacket,
+    aer_packet_copy_offsets,
+    route_coord_path,
     aer_packet_walk,
     aer_packet_area,
     find_coordxy_shortest_path,

--- a/src/paicorelib/coordinate.py
+++ b/src/paicorelib/coordinate.py
@@ -1,4 +1,3 @@
-from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum, unique
 from typing import Literal, final, overload
@@ -71,28 +70,21 @@ def _xy_parser(other: "CoordTuple2d | CoordOffset") -> CoordTuple2d:
         return other.to_tuple()
 
 
-class CoordFormat(ABC):
+@dataclass(eq=False)
+class CoordFormat:
     """
     Identifier to descripe coordinate of hardware unit.
     """
 
-    @abstractmethod
-    def __eq__(self, other) -> bool: ...
-
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
 
-    @abstractmethod
-    def __hash__(self): ...
 
-
-class CoordVecFormat(ABC):
+@dataclass(eq=False)
+class CoordVecFormat:
     """
     Identifier to descripe vector of coordinate of hardware unit.
     """
-
-    @abstractmethod
-    def __eq__(self, other) -> bool: ...
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
@@ -609,8 +601,11 @@ class CoordXY(CoordFormat):
     def __str__(self) -> str:
         return f"({self.x},{self.y})"
 
+    def to_tuple(self) -> CoordTuple2d:
+        return (self.x, self.y)
+
     def __hash__(self) -> int:
-        return hash((self.x, self.y))
+        return hash(self.to_tuple())
 
     def copy(self):
         return type(self)(self.x, self.y)
@@ -736,12 +731,16 @@ class CoordZXYOffset(CoordVecFormat):
         self.y -= other.y
         return self
 
-    def to_tuple(self) -> tuple[int, int, int]:
+    def to_tuple(self) -> CoordTuple3d:
         return (self.z, self.x, self.y)
 
     def to_xy(self) -> CoordXYOffset:
         """Convert to X-Y offset. This means no movement in Z axis, and Z-axis offset is added to X & Y axis offset."""
         return CoordXYOffset(self.z + self.x, self.z + self.y)
+
+    def l1_norm(self) -> int:
+        """Return the L1 norm of this Z/X/Y offset."""
+        return abs(self.z) + abs(self.x) + abs(self.y)
 
     def __str__(self) -> str:
         return f"({self.z},{self.x},{self.y})"
@@ -752,7 +751,7 @@ class CoordZXYOffset(CoordVecFormat):
     def copy(self):
         return type(self)(self.z, self.x, self.y)
 
-    def to_sign_magnitude(self) -> tuple[int, int, int]:
+    def to_sign_magnitude(self) -> CoordTuple3d:
         """Convert the ZXY coordinate to sign-magnitude format."""
         return coordzxy_to_sign_magnitude(self)
 
@@ -803,9 +802,7 @@ def to_coordzxyoffset(c: CoordZXYOffsetLike) -> CoordZXYOffset:
         return c
 
 
-def coordzxy_to_sign_magnitude(
-    coordzxylike: CoordZXYOffsetLike,
-) -> tuple[int, int, int]:
+def coordzxy_to_sign_magnitude(coordzxylike: CoordZXYOffsetLike) -> CoordTuple3d:
     """Convert the coordinate in ZXY format to sign-magnitude format."""
     if isinstance(coordzxylike, CoordZXYOffset):
         z, x, y = coordzxylike.to_tuple()

--- a/src/paicorelib/neuron_model.py
+++ b/src/paicorelib/neuron_model.py
@@ -17,7 +17,7 @@ from pydantic import (
     model_validator,
 )
 
-# Use `typing_extensions.TypedDict`
+# Pydantic TypeAdapter requires this on Python < 3.12.
 from typing_extensions import TypedDict
 
 from .core_defs import WeightWidth

--- a/src/paicorelib/routing_hexa.py
+++ b/src/paicorelib/routing_hexa.py
@@ -1,4 +1,3 @@
-from collections import deque
 from collections.abc import Generator
 from enum import Flag, auto
 from uuid import uuid4
@@ -6,12 +5,21 @@ from uuid import uuid4
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
-from .coordinate import CoordXY, CoordXYUnitVec, CoordZXYOffset
+from .coordinate import (
+    CoordTuple2d,
+    CoordTuple3d,
+    CoordXY,
+    CoordXYUnitVec,
+    CoordZXYOffset,
+    CoordZXYOffsetLike,
+)
 from .hw_defs import HwParamsV2
 
 __all__ = [
     "AERPacketZXYCopy",
     "AERPacket",
+    "aer_packet_copy_offsets",
+    "route_coord_path",
     "aer_packet_walk",
     "aer_packet_area",
     "find_coordxy_shortest_path",
@@ -20,6 +28,8 @@ __all__ = [
 
 @dataclass
 class AERPacketZXYCopy(CoordZXYOffset):
+    """Mutable AER copy counts. Use ``to_tuple()`` for stable dict/set keys."""
+
     z: int = Field(
         default=0,
         ge=HwParamsV2.COPY_Z_MIN,
@@ -128,14 +138,11 @@ class AERPacket:
                 move = PacketNextMove.TO_LOCAL
 
             if move == PacketNextMove.MULTICAST:
-                # The core will copy the packet, so change the foothold in place.
                 yield move, self.neighbor(dirc)
             elif move == PacketNextMove.TO_NEIGHBOR:
-                # The core will modify the foothold of the packet, so change the foothold in place.
                 self.foothold.neighbor(dirc, inplace=True)
                 yield move, None
-            else:  # TO_LOCAL
-                # The packet is arrived & stop here
+            else:
                 yield move, None
                 break
 
@@ -154,6 +161,39 @@ class AERPacket:
         return type(self)(self.foothold.copy(), self.offset.copy(), self.ncopy.copy())
 
 
+def aer_packet_copy_offsets(
+    ncopy: AERPacketZXYCopy | CoordTuple3d,
+) -> tuple[CoordXY, ...]:
+    """Return local coordinates covered by one Z/X/Y copy tuple."""
+    return tuple(_aer_packet_walk_xy(0, 0, 0, 0, 0, *_zxy_tuple(ncopy)))
+
+
+def route_coord_path(
+    start_coord: CoordXY, offset: CoordZXYOffsetLike
+) -> tuple[CoordXY, ...]:
+    """Return coordinates visited by one Z, then X, then Y route."""
+    x, y = start_coord.x, start_coord.y
+    z_offset, x_offset, y_offset = _zxy_tuple(offset)
+    path = [start_coord]
+
+    def walk(step_count: int, dx: int, dy: int) -> None:
+        nonlocal x, y
+        for _ in range(step_count):
+            x += dx
+            y += dy
+            path.append(CoordXY(x, y))
+
+    if z_offset:
+        step = 1 if z_offset > 0 else -1
+        walk(abs(z_offset), step, step)
+    if x_offset:
+        walk(abs(x_offset), 1 if x_offset > 0 else -1, 0)
+    if y_offset:
+        walk(abs(y_offset), 0, 1 if y_offset > 0 else -1)
+
+    return tuple(path)
+
+
 def aer_packet_walk(packet: AERPacket) -> list[CoordXY]:
     """
     Simulate the AER packet routing behavior of chip v2.5.
@@ -161,25 +201,169 @@ def aer_packet_walk(packet: AERPacket) -> list[CoordXY]:
     Returns:
         A list of coordinates that the packet passed through.
     """
-    queue = deque([packet])
-    cover_coords = list()  # ordered
-    visited = set()
+    return _aer_packet_walk_xy(
+        packet.foothold.x,
+        packet.foothold.y,
+        packet.offset.z,
+        packet.offset.x,
+        packet.offset.y,
+        packet.ncopy.z,
+        packet.ncopy.x,
+        packet.ncopy.y,
+    )
 
-    while queue:
-        p = queue.popleft()
-        for move, new_pkg in p:
-            cur_foot = p.foothold.copy()
-            if PacketNextMove.TO_LOCAL in move:
-                # TO_LOCAL or MULTICAST
-                if cur_foot not in visited:  # walk to a new coordinate
-                    visited.add(cur_foot)
-                    cover_coords.append(cur_foot)
 
-            if move == PacketNextMove.MULTICAST:
-                assert new_pkg is not None
-                queue.append(new_pkg)
+def _zxy_tuple(zxy: CoordZXYOffsetLike) -> CoordTuple3d:
+    if isinstance(zxy, tuple):
+        return zxy
+    return zxy.to_tuple()
 
-    return cover_coords
+
+def _append_coord(
+    coords: list[CoordXY], visited: set[CoordTuple2d], x: int, y: int
+) -> None:
+    key = (x, y)
+    if key in visited:
+        return
+    visited.add(key)
+    coords.append(CoordXY(x, y))
+
+
+def _aer_packet_walk_xy(
+    start_x: int,
+    start_y: int,
+    offset_z: int,
+    offset_x: int,
+    offset_y: int,
+    copy_z: int,
+    copy_x: int,
+    copy_y: int,
+) -> list[CoordXY]:
+    queue = [(start_x, start_y, offset_z, offset_x, offset_y, copy_z, copy_x, copy_y)]
+    coords: list[CoordXY] = []
+    visited: set[CoordTuple2d] = set()
+    queue_index = 0
+
+    while queue_index < len(queue):
+        x, y, z_offset, x_offset, y_offset, z_copy, x_copy, y_copy = queue[queue_index]
+        queue_index += 1
+
+        while True:
+            if z_offset > 0:
+                z_offset -= 1
+                x += 1
+                y += 1
+            elif z_offset < 0:
+                z_offset += 1
+                x -= 1
+                y -= 1
+            elif z_copy > 0:
+                z_copy -= 1
+                _append_coord(coords, visited, x, y)
+                queue.append(
+                    (
+                        x + 1,
+                        y + 1,
+                        z_offset,
+                        x_offset,
+                        y_offset,
+                        z_copy,
+                        x_copy,
+                        y_copy,
+                    )
+                )
+            elif z_copy < 0:
+                z_copy += 1
+                _append_coord(coords, visited, x, y)
+                queue.append(
+                    (
+                        x - 1,
+                        y - 1,
+                        z_offset,
+                        x_offset,
+                        y_offset,
+                        z_copy,
+                        x_copy,
+                        y_copy,
+                    )
+                )
+            elif x_offset > 0:
+                x_offset -= 1
+                x += 1
+            elif x_offset < 0:
+                x_offset += 1
+                x -= 1
+            elif x_copy > 0:
+                x_copy -= 1
+                _append_coord(coords, visited, x, y)
+                queue.append(
+                    (
+                        x + 1,
+                        y,
+                        z_offset,
+                        x_offset,
+                        y_offset,
+                        z_copy,
+                        x_copy,
+                        y_copy,
+                    )
+                )
+            elif x_copy < 0:
+                x_copy += 1
+                _append_coord(coords, visited, x, y)
+                queue.append(
+                    (
+                        x - 1,
+                        y,
+                        z_offset,
+                        x_offset,
+                        y_offset,
+                        z_copy,
+                        x_copy,
+                        y_copy,
+                    )
+                )
+            elif y_offset > 0:
+                y_offset -= 1
+                y += 1
+            elif y_offset < 0:
+                y_offset += 1
+                y -= 1
+            elif y_copy > 0:
+                y_copy -= 1
+                _append_coord(coords, visited, x, y)
+                queue.append(
+                    (
+                        x,
+                        y + 1,
+                        z_offset,
+                        x_offset,
+                        y_offset,
+                        z_copy,
+                        x_copy,
+                        y_copy,
+                    )
+                )
+            elif y_copy < 0:
+                y_copy += 1
+                _append_coord(coords, visited, x, y)
+                queue.append(
+                    (
+                        x,
+                        y - 1,
+                        z_offset,
+                        x_offset,
+                        y_offset,
+                        z_copy,
+                        x_copy,
+                        y_copy,
+                    )
+                )
+            else:
+                _append_coord(coords, visited, x, y)
+                break
+
+    return coords
 
 
 def aer_packet_area(ncopy: AERPacketZXYCopy | tuple[int, int, int]) -> int:

--- a/tests/test_coordinate.py
+++ b/tests/test_coordinate.py
@@ -298,6 +298,11 @@ class TestCoordXY:
         c2.neighbor(CoordXYUnitVec.Z_NEG, inplace=True)
         assert c2 == CoordXY(1, 1)
 
+    def test_to_tuple(self):
+        c = CoordXY(1, -2)
+        assert c.to_tuple() == (1, -2)
+        assert hash(c) == hash(c.to_tuple())
+
 
 class TestCoordXYOffset:
     def test_coordxyoffset_instance(self):
@@ -374,6 +379,9 @@ class TestCoordZXYOffset:
     def test_to_xy(self):
         c = CoordZXYOffset(-3, 2, -1)
         assert c.to_xy() == CoordXYOffset(-1, -4)
+
+    def test_l1_norm(self):
+        assert CoordZXYOffset(-3, 2, -1).l1_norm() == 6
 
     def test_to_sign_magnitude(self):
         c = CoordZXYOffset(-3, 1, 0)

--- a/tests/test_routing_hexa.py
+++ b/tests/test_routing_hexa.py
@@ -2,13 +2,16 @@ import itertools
 
 import pytest
 
-from paicorelib.coordinate import CoordXY, CoordZXYOffset
+from paicorelib.coordinate import CoordXY, CoordXYUnitVec, CoordZXYOffset
 from paicorelib.routing_hexa import (
     AERPacket,
     AERPacketZXYCopy,
+    PacketNextMove,
     aer_packet_area,
+    aer_packet_copy_offsets,
     aer_packet_walk,
     find_coordxy_shortest_path,
+    route_coord_path,
 )
 
 
@@ -57,6 +60,80 @@ def test_aer_package_area():
         n_covered = len(covered)
 
         assert n == n_covered
+
+
+@pytest.mark.parametrize(
+    "packet, expected",
+    [
+        (
+            AERPacket(
+                CoordXY(2, 3), CoordZXYOffset(1, -1, 0), AERPacketZXYCopy(1, 1, 0)
+            ),
+            [CoordXY(3, 4), CoordXY(2, 4), CoordXY(3, 5), CoordXY(4, 5)],
+        ),
+        (
+            AERPacket(
+                CoordXY(4, 4), CoordZXYOffset(-1, 2, -1), AERPacketZXYCopy(-1, 0, 1)
+            ),
+            [CoordXY(3, 3), CoordXY(5, 2), CoordXY(4, 1), CoordXY(5, 3), CoordXY(4, 2)],
+        ),
+    ],
+)
+def test_aer_packet_walk_preserves_zxy_order(packet, expected):
+    assert aer_packet_walk(packet) == expected
+
+
+def test_aer_packet_walk_does_not_mutate_packet():
+    packet = AERPacket(
+        CoordXY(2, 3), CoordZXYOffset(1, -1, 0), AERPacketZXYCopy(1, 1, 0)
+    )
+
+    aer_packet_walk(packet)
+
+    assert packet.foothold == CoordXY(2, 3)
+    assert packet.offset == CoordZXYOffset(1, -1, 0)
+    assert packet.ncopy == AERPacketZXYCopy(1, 1, 0)
+
+
+def test_aer_packet_neighbor_preserves_payload_and_moves_copy():
+    packet = AERPacket(
+        CoordXY(2, 3), CoordZXYOffset(1, -1, 0), AERPacketZXYCopy(1, 1, 0)
+    )
+
+    neighbor = packet.neighbor(CoordXYUnitVec.Z_POS)
+
+    assert neighbor.foothold == CoordXY(3, 4)
+    assert neighbor.offset == packet.offset
+    assert neighbor.ncopy == packet.ncopy
+    assert packet.foothold == CoordXY(2, 3)
+
+
+def test_aer_packet_iter_keeps_single_packet_debug_steps():
+    packet = AERPacket(ncopy=AERPacketZXYCopy(1, 0, 0))
+
+    first_move, new_packet = next(iter(packet))
+
+    assert first_move == PacketNextMove.MULTICAST
+    assert new_packet is not None
+    assert new_packet.foothold == CoordXY(1, 1)
+
+
+def test_aer_packet_copy_offsets_matches_zero_offset_walk():
+    ncopy = AERPacketZXYCopy(2, -1, 1)
+
+    assert list(aer_packet_copy_offsets(ncopy)) == aer_packet_walk(
+        AERPacket(ncopy=ncopy)
+    )
+
+
+def test_route_coord_path_uses_zxy_order():
+    assert route_coord_path(CoordXY(2, 3), CoordZXYOffset(1, -2, 1)) == (
+        CoordXY(2, 3),
+        CoordXY(3, 4),
+        CoordXY(2, 4),
+        CoordXY(1, 4),
+        CoordXY(1, 5),
+    )
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "platform_machine == 'armv7l'" },


### PR DESCRIPTION
## Summary

- Add reusable AER routing helpers for copy-offset expansion and Z/X/Y path expansion.
- Speed up `aer_packet_walk(...)` with a direct integer-state walker while keeping packet debug iteration APIs available.
- Add coordinate tuple/L1 helpers and focused routing/coordinate regression coverage.